### PR TITLE
[#173608840] Add email blacklist for configured services

### DIFF
--- a/CreateNotificationActivity/__tests__/utils.test.ts
+++ b/CreateNotificationActivity/__tests__/utils.test.ts
@@ -1,0 +1,36 @@
+import * as t from "io-ts";
+import { readableReport } from "italia-ts-commons/lib/reporters";
+import { FiscalCode } from "italia-ts-commons/lib/strings";
+import { parseCommaSeparatedListOf } from "../utils";
+
+describe("parseCommaSeparatedListOf", () => {
+  it.each`
+    title                                 | input                 | expected                | decoder
+    ${"undefined into an empty array"}    | ${undefined}          | ${[]}                   | ${t.any}
+    ${"empty string into an empty array"} | ${undefined}          | ${[]}                   | ${t.string}
+    ${"single element"}                   | ${"abc"}              | ${["abc"]}              | ${t.string}
+    ${"list with empty elements"}         | ${"a,,b,c,"}          | ${["a", "b", "c"]}      | ${t.string}
+    ${"'a,b,c' into ['a','b','c]"}        | ${"a,b,c"}            | ${["a", "b", "c"]}      | ${t.string}
+    ${"trim elements"}                    | ${"a , b, c "}        | ${["a", "b", "c"]}      | ${t.string}
+    ${"fiscal codes"}                     | ${"AAABBB80A01C123D"} | ${["AAABBB80A01C123D"]} | ${FiscalCode}
+  `("should parse $title", ({ input, expected, decoder }) => {
+    parseCommaSeparatedListOf(decoder)(input).fold(
+      err => {
+        fail(`cannot decode input: ${readableReport(err)}`);
+      },
+      value => {
+        expect(value).toEqual(expected);
+      }
+    );
+  });
+
+  it.each`
+    title                     | input        | decoder
+    ${"non-string values"}    | ${123}       | ${t.any}
+    ${"invalid fiscal codes"} | ${"invalid"} | ${FiscalCode}
+    ${"'1,2,3' into [1,2,3]"} | ${"1,2,3"}   | ${t.number}
+  `("should fail to parse $title", ({ input, decoder }) => {
+    const result = parseCommaSeparatedListOf(decoder)(input);
+    expect(result.isLeft()).toBeTruthy();
+  });
+});

--- a/CreateNotificationActivity/handler.ts
+++ b/CreateNotificationActivity/handler.ts
@@ -183,8 +183,8 @@ export const getCreateNotificationActivityHandler = (
   // the sender service allows email channel
   const isEmailChannelAllowed = !senderMetadata.requireSecureChannels;
 
-  // if the service is in our blacklist for sending email
-  const isInBlackList = lEmailNotificationServiceBlackList.includes(
+  // wether the service is in our blacklist for sending email
+  const isEmailDisabledForService = lEmailNotificationServiceBlackList.includes(
     createdMessageEvent.message.senderServiceId
   );
 
@@ -199,7 +199,7 @@ export const getCreateNotificationActivityHandler = (
   // * a destination email address is configured (maybeNotificationEmailAddress)
   //
   const maybeEmailNotificationAddress =
-    !isInBlackList &&
+    !isEmailDisabledForService &&
     isEmailEnabledInProfile &&
     isEmailValidatedInProfile &&
     !isEmailBlockedForService &&

--- a/CreateNotificationActivity/utils.ts
+++ b/CreateNotificationActivity/utils.ts
@@ -1,0 +1,23 @@
+import { Either } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+
+/**
+ * Parses a list of comma-separated elements into an array of typed items, using the provided decoder
+ * @param decoder a io-ts decoder
+ * @param input a string of comma-separated elements
+ *
+ * @returns either a decode error or the array of decoded items
+ */
+export const parseCommaSeparatedListOf = (decoder: t.Mixed) => (
+  input: string | undefined
+): Either<t.Errors, ReadonlyArray<t.TypeOf<typeof decoder>>> =>
+  t.readonlyArray(decoder).decode(
+    typeof input === "string"
+      ? input
+          .split(",")
+          .map(e => e.trim())
+          .filter(Boolean)
+      : !input
+      ? [] // fallback to empty array in case of empty input
+      : input // it should not happen, but in case we let the decoder fail
+  );


### PR DESCRIPTION
Added `EMAIL_NOTIFICATION_SERVICE_BLACKLIST` to add a list of services for which we don't send email, no matter what. The var is optional, default is: **no service is blacklisted**.

### Usage
```sh
# blacklist service xxx
EMAIL_NOTIFICATION_SERVICE_BLACKLIST=xxx
# blacklist both services xxx and yyy
EMAIL_NOTIFICATION_SERVICE_BLACKLIST=xxx,yyy
```
