### PR TITLE
[#174727933] Check isInboxEnabled before returning the user profile

### DIFF
--- a/GetLimitedProfile/handler.ts
+++ b/GetLimitedProfile/handler.ts
@@ -94,7 +94,9 @@ export function GetLimitedProfileHandler(
     if (isRight(maybeProfileOrError)) {
       const maybeProfile = maybeProfileOrError.value;
 
-      if (isSome(maybeProfile)) {
+      // We also return ResponseErrorNotFound in case the profile is found
+      // but the inbox is not enabled (onboarding not completed).
+      if (isSome(maybeProfile) && maybeProfile.value.isInboxEnabled) {
         const profile = maybeProfile.value;
 
         return ResponseSuccessJson(

--- a/GetLimitedProfileByPOST/__tests__/handler.test.ts
+++ b/GetLimitedProfileByPOST/__tests__/handler.test.ts
@@ -1,7 +1,10 @@
 import * as fc from "fast-check";
 import { right } from "fp-ts/lib/Either";
 import { none, some } from "fp-ts/lib/Option";
-import { ProfileModel } from "io-functions-commons/dist/src/models/profile";
+import {
+  ProfileModel,
+  RetrievedProfile
+} from "io-functions-commons/dist/src/models/profile";
 import {
   IAzureApiAuthorization,
   UserGroup
@@ -82,6 +85,48 @@ describe("GetLimitedProfileByPOSTHandler", () => {
         async (clientIp, fiscalCode) => {
           const mockProfileModel = ({
             findLastVersionByModelId: jest.fn(() => taskEither.of(none))
+          } as unknown) as ProfileModel;
+          const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
+            mockProfileModel
+          );
+
+          const response = await limitedProfileHandler(
+            {
+              ...mockAzureApiAuthorization,
+              groups: new Set([UserGroup.ApiMessageWrite])
+            },
+            clientIp,
+            mockAzureUserAttributes,
+            { fiscal_code: fiscalCode }
+          );
+
+          expect(
+            mockProfileModel.findLastVersionByModelId
+          ).toHaveBeenCalledTimes(1);
+          expect(mockProfileModel.findLastVersionByModelId).toBeCalledWith([
+            fiscalCode
+          ]);
+          expect(response.kind).toBe("IResponseErrorNotFound");
+        }
+      )
+    );
+  });
+
+  it("should respond with ResponseErrorNotFound when the requested profile doesn't have the inbox enabled", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        clientIpArb,
+        fiscalCodeArb,
+        retrievedProfileArb,
+        async (clientIp, fiscalCode, retrievedProfile) => {
+          const retrievedProfileWithInboxDisabled: RetrievedProfile = {
+            ...retrievedProfile,
+            isInboxEnabled: false
+          };
+          const mockProfileModel = ({
+            findLastVersionByModelId: jest.fn(() =>
+              taskEither.of(some(retrievedProfileWithInboxDisabled))
+            )
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
             mockProfileModel

--- a/GetLimitedProfileByPOST/handler.ts
+++ b/GetLimitedProfileByPOST/handler.ts
@@ -96,7 +96,9 @@ export function GetLimitedProfileByPOSTHandler(
     if (isRight(maybeProfileOrError)) {
       const maybeProfile = maybeProfileOrError.value;
 
-      if (isSome(maybeProfile)) {
+      // We also return ResponseErrorNotFound in case the profile is found
+      // but the inbox is not enabled (onboarding not completed).
+      if (isSome(maybeProfile) && maybeProfile.value.isInboxEnabled) {
         const profile = maybeProfile.value;
 
         return ResponseSuccessJson(

--- a/utils/arbitraries.ts
+++ b/utils/arbitraries.ts
@@ -231,6 +231,7 @@ export const retrievedProfileArb = fc
         email: email as EmailString,
         fiscalCode,
         id: `${fiscalCodeArb}-0000000000000000` as NonEmptyString,
+        isInboxEnabled: true,
         kind: "IRetrievedProfile",
         preferredLanguages: [PreferredLanguageEnum.en_GB],
         version: version as NonNegativeInteger


### PR DESCRIPTION
User profiles with isInboxEnabled=false must be treated as not existing.