### PR TITLE
[#174902061] Refactoring Api call tasks

### DIFF
--- a/GetService/handler.ts
+++ b/GetService/handler.ts
@@ -33,24 +33,16 @@ import {
 
 import { Context } from "@azure/functions";
 import { identity } from "fp-ts/lib/function";
-import {
-  fromLeft,
-  taskEither,
-  TaskEither,
-  tryCatch
-} from "fp-ts/lib/TaskEither";
+import { TaskEither } from "fp-ts/lib/TaskEither";
 import { ServiceModel } from "io-functions-commons/dist/src/models/service";
 import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { Service } from "../generated/api-admin/Service";
 import { SubscriptionKeys } from "../generated/api-admin/SubscriptionKeys";
 import { ServiceWithSubscriptionKeys } from "../generated/definitions/ServiceWithSubscriptionKeys";
+import { withApiRequestWrapper } from "../utils/api";
 import { APIClient } from "../utils/clients/admin";
 import { getLogger, ILogger } from "../utils/logging";
-import {
-  ErrorResponses,
-  toDefaultResponseErrorInternal,
-  toErrorServerResponse
-} from "../utils/responses";
+import { ErrorResponses } from "../utils/responses";
 import { serviceOwnerCheckTask } from "../utils/subscription";
 
 /**
@@ -77,28 +69,13 @@ const getServiceTask = (
   apiClient: ReturnType<APIClient>,
   serviceId: string
 ): TaskEither<ErrorResponses, Service> =>
-  tryCatch(
+  withApiRequestWrapper(
+    logger,
     () =>
       apiClient.getService({
         service_id: serviceId
       }),
-    errs => {
-      logger.logUnknown(errs);
-      return toDefaultResponseErrorInternal(errs);
-    }
-  ).foldTaskEither(
-    err => fromLeft(err),
-    errorOrResponse =>
-      errorOrResponse.fold(
-        errs => {
-          logger.logErrors(errs);
-          return fromLeft(toDefaultResponseErrorInternal(errs));
-        },
-        responseType =>
-          responseType.status !== 200
-            ? fromLeft(toErrorServerResponse(responseType))
-            : taskEither.of(responseType.value)
-      )
+    200
   );
 
 const getSubscriptionKeysTask = (
@@ -106,28 +83,13 @@ const getSubscriptionKeysTask = (
   apiClient: ReturnType<APIClient>,
   serviceId: string
 ): TaskEither<ErrorResponses, SubscriptionKeys> =>
-  tryCatch(
+  withApiRequestWrapper(
+    logger,
     () =>
       apiClient.getSubscriptionKeys({
         service_id: serviceId
       }),
-    errs => {
-      logger.logUnknown(errs);
-      return toDefaultResponseErrorInternal(errs);
-    }
-  ).foldTaskEither(
-    err => fromLeft(err),
-    errorOrResponse =>
-      errorOrResponse.fold(
-        errs => {
-          logger.logErrors(errs);
-          return fromLeft(toDefaultResponseErrorInternal(errs));
-        },
-        responseType =>
-          responseType.status !== 200
-            ? fromLeft(toErrorServerResponse(responseType))
-            : taskEither.of(responseType.value)
-      )
+    200
   );
 
 /**

--- a/RegenerateServiceKey/handler.ts
+++ b/RegenerateServiceKey/handler.ts
@@ -37,25 +37,16 @@ import {
 
 import { Context } from "@azure/functions";
 import { identity } from "fp-ts/lib/function";
-import {
-  fromLeft,
-  taskEither,
-  TaskEither,
-  tryCatch
-} from "fp-ts/lib/TaskEither";
+import { TaskEither } from "fp-ts/lib/TaskEither";
 import { ServiceModel } from "io-functions-commons/dist/src/models/service";
 import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { RequiredBodyPayloadMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_body_payload";
 import { SubscriptionKeys } from "../generated/definitions/SubscriptionKeys";
 import { SubscriptionKeyTypePayload } from "../generated/definitions/SubscriptionKeyTypePayload";
+import { withApiRequestWrapper } from "../utils/api";
 import { APIClient } from "../utils/clients/admin";
 import { getLogger, ILogger } from "../utils/logging";
-import {
-  ErrorResponses,
-  IResponseErrorUnauthorized,
-  toDefaultResponseErrorInternal,
-  toErrorServerResponse
-} from "../utils/responses";
+import { ErrorResponses, IResponseErrorUnauthorized } from "../utils/responses";
 import { serviceOwnerCheckTask } from "../utils/subscription";
 
 type ResponseTypes =
@@ -89,30 +80,15 @@ const regenerateServiceKeyTask = (
   serviceId: NonEmptyString,
   subscriptionKeyTypePayload: SubscriptionKeyTypePayload
 ): TaskEither<ErrorResponses, IResponseSuccessJson<SubscriptionKeys>> =>
-  tryCatch(
+  withApiRequestWrapper(
+    logger,
     () =>
       apiClient.RegenerateSubscriptionKeys({
         body: subscriptionKeyTypePayload,
         service_id: serviceId
       }),
-    errs => {
-      logger.logUnknown(errs);
-      return toDefaultResponseErrorInternal(errs);
-    }
-  ).foldTaskEither(
-    err => fromLeft(err),
-    errorOrResponse =>
-      errorOrResponse.fold(
-        errs => {
-          logger.logErrors(errs);
-          return fromLeft(toDefaultResponseErrorInternal(errs));
-        },
-        responseType =>
-          responseType.status !== 200
-            ? fromLeft(toErrorServerResponse(responseType))
-            : taskEither.of(ResponseSuccessJson(responseType.value))
-      )
-  );
+    200
+  ).map(ResponseSuccessJson);
 
 /**
  * Handles requests for upload a service logo by a service ID and a base64 logo' s string.

--- a/UpdateService/handler.ts
+++ b/UpdateService/handler.ts
@@ -35,12 +35,7 @@ import {
 
 import { Context } from "@azure/functions";
 import { identity } from "fp-ts/lib/function";
-import {
-  fromLeft,
-  taskEither,
-  TaskEither,
-  tryCatch
-} from "fp-ts/lib/TaskEither";
+import { TaskEither } from "fp-ts/lib/TaskEither";
 import { ServiceModel } from "io-functions-commons/dist/src/models/service";
 import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { RequiredParamMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_param";
@@ -50,14 +45,10 @@ import { SubscriptionKeys } from "../generated/api-admin/SubscriptionKeys";
 import { UserInfo } from "../generated/api-admin/UserInfo";
 import { ServicePayload } from "../generated/definitions/ServicePayload";
 import { ServiceWithSubscriptionKeys } from "../generated/definitions/ServiceWithSubscriptionKeys";
+import { withApiRequestWrapper } from "../utils/api";
 import { APIClient } from "../utils/clients/admin";
 import { getLogger, ILogger } from "../utils/logging";
-import {
-  ErrorResponses,
-  IResponseErrorUnauthorized,
-  toDefaultResponseErrorInternal,
-  toErrorServerResponse
-} from "../utils/responses";
+import { ErrorResponses, IResponseErrorUnauthorized } from "../utils/responses";
 import { serviceOwnerCheckTask } from "../utils/subscription";
 
 type ResponseTypes =
@@ -90,28 +81,13 @@ const getSubscriptionKeysTask = (
   apiClient: ReturnType<APIClient>,
   serviceId: NonEmptyString
 ): TaskEither<ErrorResponses, SubscriptionKeys> =>
-  tryCatch(
+  withApiRequestWrapper(
+    logger,
     () =>
       apiClient.getSubscriptionKeys({
         service_id: serviceId
       }),
-    errs => {
-      logger.logUnknown(errs);
-      return toDefaultResponseErrorInternal(errs);
-    }
-  ).foldTaskEither(
-    err => fromLeft(err),
-    errorOrResponse =>
-      errorOrResponse.fold(
-        errs => {
-          logger.logErrors(errs);
-          return fromLeft(toDefaultResponseErrorInternal(errs));
-        },
-        responseType =>
-          responseType.status !== 200
-            ? fromLeft(toErrorServerResponse(responseType))
-            : taskEither.of(responseType.value)
-      )
+    200
   );
 
 const getServiceTask = (
@@ -119,28 +95,13 @@ const getServiceTask = (
   apiClient: ReturnType<APIClient>,
   serviceId: NonEmptyString
 ): TaskEither<ErrorResponses, Service> =>
-  tryCatch(
+  withApiRequestWrapper(
+    logger,
     () =>
       apiClient.getService({
         service_id: serviceId
       }),
-    errs => {
-      logger.logUnknown(errs);
-      return toDefaultResponseErrorInternal(errs);
-    }
-  ).foldTaskEither(
-    err => fromLeft(err),
-    errorOrResponse =>
-      errorOrResponse.fold(
-        errs => {
-          logger.logErrors(errs);
-          return fromLeft(toDefaultResponseErrorInternal(errs));
-        },
-        responseType =>
-          responseType.status !== 200
-            ? fromLeft(toErrorServerResponse(responseType))
-            : taskEither.of(responseType.value)
-      )
+    200
   );
 
 const getUserTask = (
@@ -148,28 +109,13 @@ const getUserTask = (
   apiClient: ReturnType<APIClient>,
   userEmail: EmailString
 ): TaskEither<ErrorResponses, UserInfo> =>
-  tryCatch(
+  withApiRequestWrapper(
+    logger,
     () =>
       apiClient.getUser({
         email: userEmail
       }),
-    errs => {
-      logger.logUnknown(errs);
-      return toDefaultResponseErrorInternal(errs);
-    }
-  ).foldTaskEither(
-    err => fromLeft(err),
-    errorOrResponse =>
-      errorOrResponse.fold(
-        errs => {
-          logger.logErrors(errs);
-          return fromLeft(toDefaultResponseErrorInternal(errs));
-        },
-        responseType =>
-          responseType.status !== 200
-            ? fromLeft(toErrorServerResponse(responseType))
-            : taskEither.of(responseType.value)
-      )
+    200
   );
 
 const updateServiceTask = (
@@ -180,7 +126,8 @@ const updateServiceTask = (
   retrievedService: Service,
   adb2cTokenName: NonEmptyString
 ): TaskEither<ErrorResponses, Service> =>
-  tryCatch(
+  withApiRequestWrapper(
+    logger,
     () =>
       apiClient.updateService({
         body: {
@@ -194,23 +141,7 @@ const updateServiceTask = (
         },
         service_id: serviceId
       }),
-    errs => {
-      logger.logUnknown(errs);
-      return toDefaultResponseErrorInternal(errs);
-    }
-  ).foldTaskEither(
-    err => fromLeft(err),
-    errorOrResponse =>
-      errorOrResponse.fold(
-        errs => {
-          logger.logErrors(errs);
-          return fromLeft(toDefaultResponseErrorInternal(errs));
-        },
-        responseType =>
-          responseType.status !== 200
-            ? fromLeft(toErrorServerResponse(responseType))
-            : taskEither.of(responseType.value)
-      )
+    200
   );
 
 /**

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -18,7 +18,7 @@ export const withApiRequestWrapper = <T>(
   apiCallWithParams: () => Promise<
     t.Validation<IResponseType<number, T, never>>
   >,
-  successStatusCode: number
+  successStatusCode: 200 | 201 | 202 = 200
 ): TaskEither<ErrorResponses, T> =>
   tryCatch(
     () => apiCallWithParams(),

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -1,0 +1,42 @@
+import {
+  fromLeft,
+  TaskEither,
+  taskEither,
+  tryCatch
+} from "fp-ts/lib/TaskEither";
+import * as t from "io-ts";
+import { IResponseType } from "italia-ts-commons/lib/requests";
+import { ILogger } from "./logging";
+import {
+  ErrorResponses,
+  toDefaultResponseErrorInternal,
+  toErrorServerResponse
+} from "./responses";
+
+export const withApiRequestWrapper = <T>(
+  logger: ILogger,
+  apiCallWithParams: () => Promise<
+    t.Validation<IResponseType<number, T, never>>
+  >,
+  successStatusCode: number
+): TaskEither<ErrorResponses, T> =>
+  tryCatch(
+    () => apiCallWithParams(),
+    errs => {
+      logger.logUnknown(errs);
+      return toDefaultResponseErrorInternal(errs);
+    }
+  ).foldTaskEither(
+    err => fromLeft(err),
+    errorOrResponse =>
+      errorOrResponse.fold(
+        errs => {
+          logger.logErrors(errs);
+          return fromLeft(toDefaultResponseErrorInternal(errs));
+        },
+        responseType =>
+          responseType.status !== successStatusCode
+            ? fromLeft(toErrorServerResponse(responseType))
+            : taskEither.of(responseType.value)
+      )
+  );


### PR DESCRIPTION
This PR includes a new utility function `withApiRequestWrapper` that allows to wrap API calls and generalize a common pattern described [here](https://github.com/pagopa/io-functions-services/pull/75#discussion_r490971555).