### PR TITLE
[#175185887] Upgrade Italia-utils to allow Api auth without bearer

### DIFF
--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -583,41 +583,41 @@ definitions:
     pattern: "[0-9]{4}-[0-9]{2}-[0-9]{2}"
     x-example: "2019-09-15"
   ProblemJson:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/ProblemJson"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/ProblemJson"
   NotificationChannelStatusValue:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/NotificationChannelStatusValue"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/NotificationChannelStatusValue"
   MessageResponseWithContent:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/MessageResponseWithContent"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/MessageResponseWithContent"
   FiscalCode:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/FiscalCode"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/FiscalCode"
   LimitedProfile:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/LimitedProfile"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/LimitedProfile"
   Timestamp:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/Timestamp"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/Timestamp"
   TimeToLiveSeconds:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/TimeToLiveSeconds"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/TimeToLiveSeconds"
   MessageContent:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/MessageContent"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/MessageContent"
   NewMessage:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/NewMessage"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/NewMessage"
   CIDR:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/CIDR"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/CIDR"
   ServicePayload:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/ServicePayload"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/ServicePayload"
   Service:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/Service"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/Service"
   ServiceMetadata:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/ServiceMetadata"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/ServiceMetadata"
   ServiceScope:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/ServiceScope"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/ServiceScope"
   ServiceId:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/ServiceId"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/ServiceId"
   ServiceName:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/ServiceName"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/ServiceName"
   OrganizationName:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/OrganizationName"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/OrganizationName"
   DepartmentName:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v14.6.0/openapi/definitions.yaml#/DepartmentName"
+    $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/v15.0.0/openapi/definitions.yaml#/DepartmentName"
   SubscriptionKeys:
     type: object
     properties:

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "express": "^4.15.3",
     "fp-ts": "1.17.4",
     "html-to-text": "^4.0.0",
-    "io-functions-commons": "^14.6.0",
+    "io-functions-commons": "^15.0.0",
     "io-functions-express": "^0.1.1",
     "io-ts": "1.8.5",
     "italia-ts-commons": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "danger-plugin-digitalcitizenship": "^0.3.1",
     "fast-check": "^1.16.0",
     "italia-tslint-rules": "^1.1.3",
-    "italia-utils": "^5.1.0",
+    "italia-utils": "^6.0.0",
     "jest": "^24.8.0",
     "modclean": "^3.0.0-beta.1",
     "npm-run-all": "^4.1.5",

--- a/utils/arbitraries.ts
+++ b/utils/arbitraries.ts
@@ -96,23 +96,23 @@ export const newMessageWithDefaultEmailArb = fc
   }));
 
 export const messageTimeToLiveArb = fc
-  .integer(3600, 604801)
+  .integer(3600, 604800)
   // tslint:disable-next-line:no-useless-cast
-  .map(_ => _ as number & WithinRangeInteger<3600, 604801>);
+  .map(_ => _ as number & WithinRangeInteger<3600, 604800>);
 
 export const amountArb = fc
-  .integer(1, 10000000000)
+  .integer(1, 9999999999)
   .map(_ =>
-    WithinRangeInteger(1, 10000000000)
+    WithinRangeInteger(1, 9999999999)
       .decode(_)
       .getOrElse(undefined)
   )
   .filter(_ => _ !== undefined);
 
 export const maxAmountArb = fc
-  .integer(0, 10000000000)
+  .integer(0, 9999999999)
   // tslint:disable-next-line:no-useless-cast
-  .map(_ => _ as number & WithinRangeInteger<0, 10000000000>);
+  .map(_ => _ as number & WithinRangeInteger<0, 9999999999>);
 
 export const noticeNumberArb = fc
   .tuple(

--- a/yarn.lock
+++ b/yarn.lock
@@ -897,9 +897,9 @@ agentkeepalive@^4.1.2:
     depd "^1.1.2"
     humanize-ms "^1.2.1"
 
-"agentkeepalive@https://github.com/pagopa/agentkeepalive#v4.1.1":
+"agentkeepalive@git+https://github.com/pagopa/agentkeepalive.git#v4.1.1":
   version "4.1.0"
-  resolved "https://github.com/pagopa/agentkeepalive#91309bcab216dccbd08631e227a974afbfe807fb"
+  resolved "git+https://github.com/pagopa/agentkeepalive.git#91309bcab216dccbd08631e227a974afbfe807fb"
   dependencies:
     debug "^4.1.0"
     depd "^1.1.2"
@@ -3535,10 +3535,10 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
-io-functions-commons@^14.6.0:
-  version "14.6.0"
-  resolved "https://registry.yarnpkg.com/io-functions-commons/-/io-functions-commons-14.6.0.tgz#c420cba54a7b4d01a97e5f75e295a3668a14cf6c"
-  integrity sha512-8vWY2aZgjCMZvQGKeiII+8wQYH7be1ghDG/jTu6+yE9/SDR90L2BFSwb4n1KihX5wugM3h5ne3UVhWVRV/S+tw==
+io-functions-commons@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/io-functions-commons/-/io-functions-commons-15.0.0.tgz#a0857853ad9f7da4a44ca8dbbcfa72a221789180"
+  integrity sha512-Fls5OMJNpMXX/p3O4Y644yUCWuHLY65+be7M2Yodo9x3JVBI5qZmpj+EOLb+HA0kjUZD0Z/vW1gD6kJiukXjlA==
   dependencies:
     "@azure/cosmos" "^3.7.2"
     "@types/node-fetch" "^2.5.6"
@@ -3972,9 +3972,9 @@ istanbul-reports@^2.2.6:
     html-escaper "^2.0.0"
 
 italia-ts-commons@^5.0.1:
-  version "5.1.9"
-  resolved "https://registry.yarnpkg.com/italia-ts-commons/-/italia-ts-commons-5.1.9.tgz#827b63d6f02c0c80ecb06bbf7991161bd1019870"
-  integrity sha512-mIh+cDpOJZ7S0Q6GmdHUAT0nKb9+HQ98wN8HHD0WQ9HlhWhJEKn9I0ryXqQHpiilFQS6ifAW0u9Cy8pLmMHlqg==
+  version "5.1.13"
+  resolved "https://registry.yarnpkg.com/italia-ts-commons/-/italia-ts-commons-5.1.13.tgz#7ae919374f9c03c04e38603b7f7e9681ebee79b7"
+  integrity sha512-mXtrNG/HR6lRCOTtBrEzsxGmkHccoDXKqoc9i+J2+yGhhxcznASu+0KMC05ZR1yJP4bWliC9rXJ3hnCw0rMSnQ==
   dependencies:
     fp-ts "1.12.0"
     io-ts "1.8.5"
@@ -3995,9 +3995,9 @@ italia-ts-commons@^7.0.1:
     validator "^10.1.0"
 
 italia-ts-commons@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/italia-ts-commons/-/italia-ts-commons-8.1.0.tgz#929c805a7d9e8877fef26436946bf3ee76a76c82"
-  integrity sha512-d03UKxjeIX+4otNgZaDoS8t1l+gVEHD/q/JsQox1CC3nAiKHQ9TFNv4BdHIiUIswgpx1szjT6lzeJQUCUL++YA==
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/italia-ts-commons/-/italia-ts-commons-8.5.0.tgz#9967ec1b94745f482d5cc942a1bacf7de6f6461b"
+  integrity sha512-pTX90/WW987t7pdcbQngCFm35c3gQlDFIUCnDZ6VCo5vNMl8VwdZztGIcYyEaJw6xMjb1WjSRlltnDdSe0B9Eg==
   dependencies:
     abort-controller "^3.0.0"
     agentkeepalive "^4.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4021,15 +4021,16 @@ italia-tslint-rules@^1.1.3:
     tslint-sonarts "^1.9.0"
     typestrict "^1.0.2"
 
-italia-utils@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/italia-utils/-/italia-utils-5.1.0.tgz#6c53609600925c8c1467889867e82840e2ebe7ff"
-  integrity sha512-MiwaB4z9RkZTWrcZmYfH25F+EJrMCjHyPEQuxGU/LIcx0AQqdQaaTcXadInN6RhS0tg3kGLRBRctu4++tFLHbA==
+italia-utils@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/italia-utils/-/italia-utils-6.0.0.tgz#f424d1e4077606aea444e6a6af101f107ff83675"
+  integrity sha512-p4n3953whfOmwQeE4yiyeW63QsdHrZXq3fGBIFhcHVAOT0wPdly8RA78nfjLgcEb6ZHccxDnARs8D4GcHdT38Q==
   dependencies:
     fs-extra "^6.0.0"
     italia-ts-commons "^5.0.1"
     nunjucks "^3.1.2"
     prettier "^1.12.1"
+    safe-identifier "^0.4.2"
     swagger-parser "^7.0.0"
     write-yaml-file "^4.1.0"
     yargs "^11.1.0"
@@ -6448,6 +6449,11 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
+
+safe-identifier@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/safe-identifier/-/safe-identifier-0.4.2.tgz#cf6bfca31c2897c588092d1750d30ef501d59fcb"
+  integrity sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==
 
 safe-regex@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This PR is intended to avoid generated api clients to use `Bearer` token authentication while calling io-functions-admin APIs