### PR TITLE
Added '@pagopa/' to package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "io-functions-services",
+  "name": "@pagopa/io-functions-services",
   "version": "1.13.1",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
In order to generate a correct client SDK, added "@pagopa/" to the package name