### PR TITLE
[#ENTE-20] Update @pagopa/io-functions-commons fix authorized cidrs

### DIFF
--- a/CreateMessage/__tests__/handler.test.ts
+++ b/CreateMessage/__tests__/handler.test.ts
@@ -2,8 +2,8 @@
 
 import * as fc from "fast-check";
 
-import { MessageModel } from "io-functions-commons/dist/src/models/message";
-import { UserGroup } from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+import { MessageModel } from "@pagopa/io-functions-commons/dist/src/models/message";
+import { UserGroup } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 
 import { none, some } from "fp-ts/lib/Option";
 

--- a/CreateMessage/handler.ts
+++ b/CreateMessage/handler.ts
@@ -14,48 +14,48 @@ import { fromEither, TaskEither, tryCatch } from "fp-ts/lib/TaskEither";
 
 import * as t from "io-ts";
 
-import { FiscalCode } from "io-functions-commons/dist/generated/definitions/FiscalCode";
-import { NewMessage as ApiNewMessage } from "io-functions-commons/dist/generated/definitions/NewMessage";
-import { TimeToLiveSeconds } from "io-functions-commons/dist/generated/definitions/TimeToLiveSeconds";
-import { CreatedMessageEvent } from "io-functions-commons/dist/src/models/created_message_event";
+import { FiscalCode } from "@pagopa/io-functions-commons/dist/generated/definitions/FiscalCode";
+import { NewMessage as ApiNewMessage } from "@pagopa/io-functions-commons/dist/generated/definitions/NewMessage";
+import { TimeToLiveSeconds } from "@pagopa/io-functions-commons/dist/generated/definitions/TimeToLiveSeconds";
+import { CreatedMessageEvent } from "@pagopa/io-functions-commons/dist/src/models/created_message_event";
 import {
   Message,
   MessageModel,
   NewMessageWithoutContent
-} from "io-functions-commons/dist/src/models/message";
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
+} from "@pagopa/io-functions-commons/dist/src/models/message";
+import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 import {
   AzureUserAttributesMiddleware,
   IAzureUserAttributes
-} from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 import {
   ClientIp,
   ClientIpMiddleware
-} from "io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
-import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
-import { OptionalFiscalCodeMiddleware } from "io-functions-commons/dist/src/utils/middlewares/fiscalcode";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { OptionalFiscalCodeMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/fiscalcode";
 import {
   IRequestMiddleware,
   withRequestMiddlewares,
   wrapRequestHandler
-} from "io-functions-commons/dist/src/utils/request_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
 import {
   IResponseErrorQuery,
   ResponseErrorQuery
-} from "io-functions-commons/dist/src/utils/response";
+} from "@pagopa/io-functions-commons/dist/src/utils/response";
 import {
   checkSourceIpForHandler,
   clientIPAndCidrTuple as ipTuple
-} from "io-functions-commons/dist/src/utils/source_ip_check";
+} from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 import {
   ObjectIdGenerator,
   ulidGenerator
-} from "io-functions-commons/dist/src/utils/strings";
+} from "@pagopa/io-functions-commons/dist/src/utils/strings";
 
 import { initAppInsights } from "italia-ts-commons/lib/appinsights";
 import { readableReport } from "italia-ts-commons/lib/reporters";

--- a/CreateMessage/index.ts
+++ b/CreateMessage/index.ts
@@ -7,17 +7,17 @@ import * as express from "express";
 import {
   MESSAGE_COLLECTION_NAME,
   MessageModel
-} from "io-functions-commons/dist/src/models/message";
+} from "@pagopa/io-functions-commons/dist/src/models/message";
 import {
   SERVICE_COLLECTION_NAME,
   ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
-import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+} from "@pagopa/io-functions-commons/dist/src/models/service";
+import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
+import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
-import { withAppInsightsContext } from "io-functions-commons/dist/src/utils/application_insights";
+import { withAppInsightsContext } from "@pagopa/io-functions-commons/dist/src/utils/application_insights";
 import { initTelemetryClient } from "../utils/appinsights";
 import { CreateMessage } from "./handler";
 

--- a/CreateNotificationActivity/handler.ts
+++ b/CreateNotificationActivity/handler.ts
@@ -9,26 +9,26 @@ import { fromNullable, none, Option, some } from "fp-ts/lib/Option";
 
 import { readableReport } from "italia-ts-commons/lib/reporters";
 
-import { BlockedInboxOrChannelEnum } from "io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
-import { FiscalCode } from "io-functions-commons/dist/generated/definitions/FiscalCode";
-import { HttpsUrl } from "io-functions-commons/dist/generated/definitions/HttpsUrl";
-import { MessageContent } from "io-functions-commons/dist/generated/definitions/MessageContent";
-import { NotificationChannelEnum } from "io-functions-commons/dist/generated/definitions/NotificationChannel";
-import { CreatedMessageEvent } from "io-functions-commons/dist/src/models/created_message_event";
-import { CreatedMessageEventSenderMetadata } from "io-functions-commons/dist/src/models/created_message_sender_metadata";
-import { NewMessageWithoutContent } from "io-functions-commons/dist/src/models/message";
+import { BlockedInboxOrChannelEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
+import { FiscalCode } from "@pagopa/io-functions-commons/dist/generated/definitions/FiscalCode";
+import { HttpsUrl } from "@pagopa/io-functions-commons/dist/generated/definitions/HttpsUrl";
+import { MessageContent } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageContent";
+import { NotificationChannelEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/NotificationChannel";
+import { CreatedMessageEvent } from "@pagopa/io-functions-commons/dist/src/models/created_message_event";
+import { CreatedMessageEventSenderMetadata } from "@pagopa/io-functions-commons/dist/src/models/created_message_sender_metadata";
+import { NewMessageWithoutContent } from "@pagopa/io-functions-commons/dist/src/models/message";
 import {
   createNewNotification,
   NewNotification,
   NotificationAddressSourceEnum,
   NotificationChannelEmail,
   NotificationModel
-} from "io-functions-commons/dist/src/models/notification";
-import { NotificationEvent } from "io-functions-commons/dist/src/models/notification_event";
-import { RetrievedProfile } from "io-functions-commons/dist/src/models/profile";
-import { ulidGenerator } from "io-functions-commons/dist/src/utils/strings";
+} from "@pagopa/io-functions-commons/dist/src/models/notification";
+import { NotificationEvent } from "@pagopa/io-functions-commons/dist/src/models/notification_event";
+import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/profile";
+import { ulidGenerator } from "@pagopa/io-functions-commons/dist/src/utils/strings";
 
-import { ServiceId } from "io-functions-commons/dist/generated/definitions/ServiceId";
+import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
 import { SuccessfulStoreMessageContentActivityResult } from "../StoreMessageContentActivity/handler";
 
 /**

--- a/CreateNotificationActivity/index.ts
+++ b/CreateNotificationActivity/index.ts
@@ -11,13 +11,13 @@
 import { AzureFunction } from "@azure/functions";
 import { cosmosdbInstance } from "../utils/cosmosdb";
 
-import { FiscalCode } from "io-functions-commons/dist/generated/definitions/FiscalCode";
-import { HttpsUrl } from "io-functions-commons/dist/generated/definitions/HttpsUrl";
+import { FiscalCode } from "@pagopa/io-functions-commons/dist/generated/definitions/FiscalCode";
+import { HttpsUrl } from "@pagopa/io-functions-commons/dist/generated/definitions/HttpsUrl";
 
 import {
   NOTIFICATION_COLLECTION_NAME,
   NotificationModel
-} from "io-functions-commons/dist/src/models/notification";
+} from "@pagopa/io-functions-commons/dist/src/models/notification";
 
 import { getCreateNotificationActivityHandler } from "./handler";
 

--- a/CreateService/__tests__/handler.test.ts
+++ b/CreateService/__tests__/handler.test.ts
@@ -6,8 +6,8 @@
 import {
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
-import { IAzureUserAttributes } from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+import { IAzureUserAttributes } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 
 import { NonNegativeInteger } from "italia-ts-commons/lib/numbers";
 import {
@@ -16,11 +16,11 @@ import {
   OrganizationFiscalCode
 } from "italia-ts-commons/lib/strings";
 
-import { MaxAllowedPaymentAmount } from "io-functions-commons/dist/generated/definitions/MaxAllowedPaymentAmount";
+import { MaxAllowedPaymentAmount } from "@pagopa/io-functions-commons/dist/generated/definitions/MaxAllowedPaymentAmount";
 
 import { left, right } from "fp-ts/lib/Either";
-import { ServiceScopeEnum } from "io-functions-commons/dist/generated/definitions/ServiceScope";
-import { ServiceMetadata } from "io-functions-commons/dist/src/models/service";
+import { ServiceScopeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceScope";
+import { ServiceMetadata } from "@pagopa/io-functions-commons/dist/src/models/service";
 import * as reporters from "italia-ts-commons/lib/reporters";
 import { Subscription } from "../../generated/api-admin/Subscription";
 import { UserInfo } from "../../generated/api-admin/UserInfo";

--- a/CreateService/handler.ts
+++ b/CreateService/handler.ts
@@ -3,21 +3,21 @@ import * as express from "express";
 import {
   ClientIp,
   ClientIpMiddleware
-} from "io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
 
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 import {
   AzureUserAttributesMiddleware,
   IAzureUserAttributes
-} from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 import {
   withRequestMiddlewares,
   wrapRequestHandler
-} from "io-functions-commons/dist/src/utils/request_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
 import {
   IResponseErrorForbiddenNotAuthorized,
   IResponseErrorInternal,
@@ -30,18 +30,18 @@ import {
 import {
   checkSourceIpForHandler,
   clientIPAndCidrTuple as ipTuple
-} from "io-functions-commons/dist/src/utils/source_ip_check";
+} from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
 import { Context } from "@azure/functions";
 import { identity } from "fp-ts/lib/function";
 import { TaskEither } from "fp-ts/lib/TaskEither";
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
-import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
-import { RequiredBodyPayloadMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_body_payload";
+import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
+import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { RequiredBodyPayloadMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_body_payload";
 import {
   ObjectIdGenerator,
   ulidGenerator
-} from "io-functions-commons/dist/src/utils/strings";
+} from "@pagopa/io-functions-commons/dist/src/utils/strings";
 import { initAppInsights } from "italia-ts-commons/lib/appinsights";
 import {
   EmailString,

--- a/CreateService/handler.ts
+++ b/CreateService/handler.ts
@@ -33,8 +33,6 @@ import {
 } from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
 import { Context } from "@azure/functions";
-import { identity } from "fp-ts/lib/function";
-import { TaskEither } from "fp-ts/lib/TaskEither";
 import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
 import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { RequiredBodyPayloadMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_body_payload";
@@ -42,6 +40,8 @@ import {
   ObjectIdGenerator,
   ulidGenerator
 } from "@pagopa/io-functions-commons/dist/src/utils/strings";
+import { identity } from "fp-ts/lib/function";
+import { TaskEither } from "fp-ts/lib/TaskEither";
 import { initAppInsights } from "italia-ts-commons/lib/appinsights";
 import {
   EmailString,

--- a/CreateService/index.ts
+++ b/CreateService/index.ts
@@ -6,9 +6,9 @@ import { cosmosdbInstance } from "../utils/cosmosdb";
 import {
   SERVICE_COLLECTION_NAME,
   ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
-import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+} from "@pagopa/io-functions-commons/dist/src/models/service";
+import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
+import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 

--- a/CreatedMessageOrchestrator/index.ts
+++ b/CreatedMessageOrchestrator/index.ts
@@ -3,11 +3,11 @@ import { IOrchestrationFunctionContext } from "durable-functions/lib/src/classes
 
 import { readableReport } from "italia-ts-commons/lib/reporters";
 
-import { NotificationChannelEnum } from "io-functions-commons/dist/generated/definitions/NotificationChannel";
-import { NotificationChannelStatusValueEnum } from "io-functions-commons/dist/generated/definitions/NotificationChannelStatusValue";
-import { CreatedMessageEvent } from "io-functions-commons/dist/src/models/created_message_event";
+import { NotificationChannelEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/NotificationChannel";
+import { NotificationChannelStatusValueEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/NotificationChannelStatusValue";
+import { CreatedMessageEvent } from "@pagopa/io-functions-commons/dist/src/models/created_message_event";
 
-import { MessageStatusValueEnum } from "io-functions-commons/dist/generated/definitions/MessageStatusValue";
+import { MessageStatusValueEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageStatusValue";
 import {
   CreateNotificationActivityInput,
   CreateNotificationActivityResult

--- a/EmailNotificationActivity/__tests__/handler.test.ts
+++ b/EmailNotificationActivity/__tests__/handler.test.ts
@@ -16,21 +16,21 @@ import {
 import { some } from "fp-ts/lib/Option";
 import { fromLeft, taskEither } from "fp-ts/lib/TaskEither";
 
-import { EmailAddress } from "io-functions-commons/dist/generated/definitions/EmailAddress";
-import { MessageBodyMarkdown } from "io-functions-commons/dist/generated/definitions/MessageBodyMarkdown";
-import { MessageContent } from "io-functions-commons/dist/generated/definitions/MessageContent";
-import { MessageSubject } from "io-functions-commons/dist/generated/definitions/MessageSubject";
-import { TimeToLiveSeconds } from "io-functions-commons/dist/generated/definitions/TimeToLiveSeconds";
+import { EmailAddress } from "@pagopa/io-functions-commons/dist/generated/definitions/EmailAddress";
+import { MessageBodyMarkdown } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageBodyMarkdown";
+import { MessageContent } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageContent";
+import { MessageSubject } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageSubject";
+import { TimeToLiveSeconds } from "@pagopa/io-functions-commons/dist/generated/definitions/TimeToLiveSeconds";
 
-import { NotificationChannelEnum } from "io-functions-commons/dist/generated/definitions/NotificationChannel";
-import * as mail from "io-functions-commons/dist/src/mailer";
-import { CreatedMessageEventSenderMetadata } from "io-functions-commons/dist/src/models/created_message_sender_metadata";
+import { NotificationChannelEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/NotificationChannel";
+import * as mail from "@pagopa/io-functions-commons/dist/src/mailer";
+import { CreatedMessageEventSenderMetadata } from "@pagopa/io-functions-commons/dist/src/models/created_message_sender_metadata";
 import {
   NewNotification,
   NotificationAddressSourceEnum,
   NotificationModel,
   RetrievedNotification
-} from "io-functions-commons/dist/src/models/notification";
+} from "@pagopa/io-functions-commons/dist/src/models/notification";
 
 beforeEach(() => jest.clearAllMocks());
 

--- a/EmailNotificationActivity/handler.ts
+++ b/EmailNotificationActivity/handler.ts
@@ -8,16 +8,16 @@ import * as NodeMailer from "nodemailer";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 
-import { ActiveMessage } from "io-functions-commons/dist/src/models/message";
+import { ActiveMessage } from "@pagopa/io-functions-commons/dist/src/models/message";
 import {
   EmailNotification,
   NotificationModel
-} from "io-functions-commons/dist/src/models/notification";
-import { NotificationEvent } from "io-functions-commons/dist/src/models/notification_event";
+} from "@pagopa/io-functions-commons/dist/src/models/notification";
+import { NotificationEvent } from "@pagopa/io-functions-commons/dist/src/models/notification_event";
 
 import { generateDocumentHtml } from "./utils";
 
-import { sendMail } from "io-functions-commons/dist/src/mailer";
+import { sendMail } from "@pagopa/io-functions-commons/dist/src/mailer";
 
 export interface INotificationDefaults {
   readonly HTML_TO_TEXT_OPTIONS: HtmlToTextOptions;

--- a/EmailNotificationActivity/index.ts
+++ b/EmailNotificationActivity/index.ts
@@ -14,11 +14,11 @@ import { cosmosdbInstance } from "../utils/cosmosdb";
 import {
   NOTIFICATION_COLLECTION_NAME,
   NotificationModel
-} from "io-functions-commons/dist/src/models/notification";
+} from "@pagopa/io-functions-commons/dist/src/models/notification";
 
 import { getEmailNotificationActivityHandler } from "./handler";
 
-import { getMailerTransporter } from "io-functions-commons/dist/src/mailer";
+import { getMailerTransporter } from "@pagopa/io-functions-commons/dist/src/mailer";
 import { getConfigOrThrow } from "../utils/config";
 
 const config = getConfigOrThrow();

--- a/EmailNotificationActivity/utils.ts
+++ b/EmailNotificationActivity/utils.ts
@@ -1,12 +1,12 @@
 import { Either, left, right } from "fp-ts/lib/Either";
 import * as NodeMailer from "nodemailer";
 
-import { MessageBodyMarkdown } from "io-functions-commons/dist/generated/definitions/MessageBodyMarkdown";
-import { MessageSubject } from "io-functions-commons/dist/generated/definitions/MessageSubject";
-import { CreatedMessageEventSenderMetadata } from "io-functions-commons/dist/src/models/created_message_sender_metadata";
-import { markdownToHtml } from "io-functions-commons/dist/src/utils/markdown";
+import { MessageBodyMarkdown } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageBodyMarkdown";
+import { MessageSubject } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageSubject";
+import { CreatedMessageEventSenderMetadata } from "@pagopa/io-functions-commons/dist/src/models/created_message_sender_metadata";
+import { markdownToHtml } from "@pagopa/io-functions-commons/dist/src/utils/markdown";
 
-import defaultEmailTemplate from "io-functions-commons/dist/src/templates/html/default";
+import defaultEmailTemplate from "@pagopa/io-functions-commons/dist/src/templates/html/default";
 
 const defaultEmailFooterMarkdown = `**Non rispondere a questa email. Questa casella di posta è utilizzata solo per l'invio della presente mail e, non essendo monitorata, non riceveresti risposta.**
 

--- a/GetLimitedProfile/__tests__/handler.test.ts
+++ b/GetLimitedProfile/__tests__/handler.test.ts
@@ -4,12 +4,12 @@ import { none, some } from "fp-ts/lib/Option";
 import {
   ProfileModel,
   RetrievedProfile
-} from "io-functions-commons/dist/src/models/profile";
+} from "@pagopa/io-functions-commons/dist/src/models/profile";
 import {
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
-import { IAzureUserAttributes } from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+import { IAzureUserAttributes } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 import {
   EmailString,
   FiscalCode,

--- a/GetLimitedProfile/handler.ts
+++ b/GetLimitedProfile/handler.ts
@@ -1,6 +1,3 @@
-import * as express from "express";
-import { isLeft, isRight } from "fp-ts/lib/Either";
-import { isSome } from "fp-ts/lib/Option";
 import { LimitedProfile } from "@pagopa/io-functions-commons/dist/generated/definitions/LimitedProfile";
 import { ProfileModel } from "@pagopa/io-functions-commons/dist/src/models/profile";
 import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
@@ -30,6 +27,9 @@ import {
   checkSourceIpForHandler,
   clientIPAndCidrTuple as ipTuple
 } from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
+import * as express from "express";
+import { isLeft, isRight } from "fp-ts/lib/Either";
+import { isSome } from "fp-ts/lib/Option";
 import {
   IResponseErrorForbiddenNotAuthorizedForRecipient,
   IResponseErrorNotFound,

--- a/GetLimitedProfile/handler.ts
+++ b/GetLimitedProfile/handler.ts
@@ -1,35 +1,35 @@
 import * as express from "express";
 import { isLeft, isRight } from "fp-ts/lib/Either";
 import { isSome } from "fp-ts/lib/Option";
-import { LimitedProfile } from "io-functions-commons/dist/generated/definitions/LimitedProfile";
-import { ProfileModel } from "io-functions-commons/dist/src/models/profile";
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
+import { LimitedProfile } from "@pagopa/io-functions-commons/dist/generated/definitions/LimitedProfile";
+import { ProfileModel } from "@pagopa/io-functions-commons/dist/src/models/profile";
+import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 import {
   AzureUserAttributesMiddleware,
   IAzureUserAttributes
-} from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 import {
   ClientIp,
   ClientIpMiddleware
-} from "io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
-import { FiscalCodeMiddleware } from "io-functions-commons/dist/src/utils/middlewares/fiscalcode";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+import { FiscalCodeMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/fiscalcode";
 import {
   withRequestMiddlewares,
   wrapRequestHandler
-} from "io-functions-commons/dist/src/utils/request_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
 import {
   IResponseErrorQuery,
   ResponseErrorQuery
-} from "io-functions-commons/dist/src/utils/response";
+} from "@pagopa/io-functions-commons/dist/src/utils/response";
 import {
   checkSourceIpForHandler,
   clientIPAndCidrTuple as ipTuple
-} from "io-functions-commons/dist/src/utils/source_ip_check";
+} from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 import {
   IResponseErrorForbiddenNotAuthorizedForRecipient,
   IResponseErrorNotFound,

--- a/GetLimitedProfile/index.ts
+++ b/GetLimitedProfile/index.ts
@@ -1,6 +1,4 @@
 import { Context } from "@azure/functions";
-import cors = require("cors");
-import express = require("express");
 import {
   PROFILE_COLLECTION_NAME,
   ProfileModel
@@ -11,6 +9,8 @@ import {
 } from "@pagopa/io-functions-commons/dist/src/models/service";
 import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
 import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import cors = require("cors");
+import express = require("express");
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 import { cosmosdbInstance } from "../utils/cosmosdb";
 

--- a/GetLimitedProfile/index.ts
+++ b/GetLimitedProfile/index.ts
@@ -4,13 +4,13 @@ import express = require("express");
 import {
   PROFILE_COLLECTION_NAME,
   ProfileModel
-} from "io-functions-commons/dist/src/models/profile";
+} from "@pagopa/io-functions-commons/dist/src/models/profile";
 import {
   SERVICE_COLLECTION_NAME,
   ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
-import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+} from "@pagopa/io-functions-commons/dist/src/models/service";
+import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
+import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 import { cosmosdbInstance } from "../utils/cosmosdb";
 

--- a/GetLimitedProfileByPOST/__tests__/handler.test.ts
+++ b/GetLimitedProfileByPOST/__tests__/handler.test.ts
@@ -1,6 +1,3 @@
-import * as fc from "fast-check";
-import { right } from "fp-ts/lib/Either";
-import { none, some } from "fp-ts/lib/Option";
 import {
   ProfileModel,
   RetrievedProfile
@@ -10,6 +7,8 @@ import {
   UserGroup
 } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 import { IAzureUserAttributes } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+import * as fc from "fast-check";
+import { none, some } from "fp-ts/lib/Option";
 import {
   EmailString,
   FiscalCode,

--- a/GetLimitedProfileByPOST/__tests__/handler.test.ts
+++ b/GetLimitedProfileByPOST/__tests__/handler.test.ts
@@ -4,12 +4,12 @@ import { none, some } from "fp-ts/lib/Option";
 import {
   ProfileModel,
   RetrievedProfile
-} from "io-functions-commons/dist/src/models/profile";
+} from "@pagopa/io-functions-commons/dist/src/models/profile";
 import {
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
-import { IAzureUserAttributes } from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+import { IAzureUserAttributes } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 import {
   EmailString,
   FiscalCode,

--- a/GetLimitedProfileByPOST/handler.ts
+++ b/GetLimitedProfileByPOST/handler.ts
@@ -3,34 +3,34 @@ import * as express from "express";
 import { isLeft, isRight } from "fp-ts/lib/Either";
 import { isSome } from "fp-ts/lib/Option";
 
-import { LimitedProfile } from "io-functions-commons/dist/generated/definitions/LimitedProfile";
-import { ProfileModel } from "io-functions-commons/dist/src/models/profile";
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
+import { LimitedProfile } from "@pagopa/io-functions-commons/dist/generated/definitions/LimitedProfile";
+import { ProfileModel } from "@pagopa/io-functions-commons/dist/src/models/profile";
+import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 import {
   AzureUserAttributesMiddleware,
   IAzureUserAttributes
-} from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 import {
   ClientIp,
   ClientIpMiddleware
-} from "io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
 import {
   withRequestMiddlewares,
   wrapRequestHandler
-} from "io-functions-commons/dist/src/utils/request_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
 import {
   IResponseErrorQuery,
   ResponseErrorQuery
-} from "io-functions-commons/dist/src/utils/response";
+} from "@pagopa/io-functions-commons/dist/src/utils/response";
 import {
   checkSourceIpForHandler,
   clientIPAndCidrTuple as ipTuple
-} from "io-functions-commons/dist/src/utils/source_ip_check";
+} from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 import {
   IResponseErrorForbiddenNotAuthorizedForRecipient,
   IResponseErrorNotFound,

--- a/GetLimitedProfileByPOST/index.ts
+++ b/GetLimitedProfileByPOST/index.ts
@@ -1,6 +1,4 @@
 import { Context } from "@azure/functions";
-import cors = require("cors");
-import express = require("express");
 import {
   PROFILE_COLLECTION_NAME,
   ProfileModel
@@ -11,6 +9,8 @@ import {
 } from "@pagopa/io-functions-commons/dist/src/models/service";
 import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
 import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import cors = require("cors");
+import express = require("express");
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 import { cosmosdbInstance } from "../utils/cosmosdb";
 

--- a/GetLimitedProfileByPOST/index.ts
+++ b/GetLimitedProfileByPOST/index.ts
@@ -4,13 +4,13 @@ import express = require("express");
 import {
   PROFILE_COLLECTION_NAME,
   ProfileModel
-} from "io-functions-commons/dist/src/models/profile";
+} from "@pagopa/io-functions-commons/dist/src/models/profile";
 import {
   SERVICE_COLLECTION_NAME,
   ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
-import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+} from "@pagopa/io-functions-commons/dist/src/models/service";
+import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
+import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 import { cosmosdbInstance } from "../utils/cosmosdb";
 

--- a/GetMessage/__tests__/handler.test.ts
+++ b/GetMessage/__tests__/handler.test.ts
@@ -9,8 +9,8 @@ import { QueryError } from "documentdb";
 import {
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
-import { IAzureUserAttributes } from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+import { IAzureUserAttributes } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 
 import { NonNegativeInteger } from "italia-ts-commons/lib/numbers";
 import {
@@ -23,26 +23,26 @@ import {
 import {
   NewMessageWithoutContent,
   RetrievedMessageWithoutContent
-} from "io-functions-commons/dist/src/models/message";
-import { MessageStatus } from "io-functions-commons/dist/src/models/message_status";
+} from "@pagopa/io-functions-commons/dist/src/models/message";
+import { MessageStatus } from "@pagopa/io-functions-commons/dist/src/models/message_status";
 import {
   NotificationAddressSourceEnum,
   RetrievedNotification
-} from "io-functions-commons/dist/src/models/notification";
+} from "@pagopa/io-functions-commons/dist/src/models/notification";
 import {
   makeStatusId,
   RetrievedNotificationStatus
-} from "io-functions-commons/dist/src/models/notification_status";
-import { toAuthorizedCIDRs } from "io-functions-commons/dist/src/models/service";
+} from "@pagopa/io-functions-commons/dist/src/models/notification_status";
+import { toAuthorizedCIDRs } from "@pagopa/io-functions-commons/dist/src/models/service";
 
-import { CreatedMessageWithoutContent } from "io-functions-commons/dist/generated/definitions/CreatedMessageWithoutContent";
-import { MaxAllowedPaymentAmount } from "io-functions-commons/dist/generated/definitions/MaxAllowedPaymentAmount";
-import { MessageResponseWithoutContent } from "io-functions-commons/dist/generated/definitions/MessageResponseWithoutContent";
-import { MessageStatusValueEnum } from "io-functions-commons/dist/generated/definitions/MessageStatusValue";
-import { NotificationChannelEnum } from "io-functions-commons/dist/generated/definitions/NotificationChannel";
-import { NotificationChannelStatusValueEnum } from "io-functions-commons/dist/generated/definitions/NotificationChannelStatusValue";
-import { ServiceId } from "io-functions-commons/dist/generated/definitions/ServiceId";
-import { TimeToLiveSeconds } from "io-functions-commons/dist/generated/definitions/TimeToLiveSeconds";
+import { CreatedMessageWithoutContent } from "@pagopa/io-functions-commons/dist/generated/definitions/CreatedMessageWithoutContent";
+import { MaxAllowedPaymentAmount } from "@pagopa/io-functions-commons/dist/generated/definitions/MaxAllowedPaymentAmount";
+import { MessageResponseWithoutContent } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageResponseWithoutContent";
+import { MessageStatusValueEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageStatusValue";
+import { NotificationChannelEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/NotificationChannel";
+import { NotificationChannelStatusValueEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/NotificationChannelStatusValue";
+import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
+import { TimeToLiveSeconds } from "@pagopa/io-functions-commons/dist/generated/definitions/TimeToLiveSeconds";
 
 import { fromLeft, taskEither, TaskEither } from "fp-ts/lib/TaskEither";
 import { GetMessageHandler } from "../handler";

--- a/GetMessage/handler.ts
+++ b/GetMessage/handler.ts
@@ -3,29 +3,29 @@ import * as express from "express";
 import {
   ClientIp,
   ClientIpMiddleware
-} from "io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
 
-import { RequiredParamMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_param";
+import { RequiredParamMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_param";
 
 import {
   IResponseErrorQuery,
   ResponseErrorQuery
-} from "io-functions-commons/dist/src/utils/response";
+} from "@pagopa/io-functions-commons/dist/src/utils/response";
 
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 import {
   AzureUserAttributesMiddleware,
   IAzureUserAttributes
-} from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
-import { FiscalCodeMiddleware } from "io-functions-commons/dist/src/utils/middlewares/fiscalcode";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+import { FiscalCodeMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/fiscalcode";
 import {
   withRequestMiddlewares,
   wrapRequestHandler
-} from "io-functions-commons/dist/src/utils/request_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
 import {
   IResponseErrorForbiddenNotAuthorized,
   IResponseErrorInternal,
@@ -43,31 +43,31 @@ import { FiscalCode, NonEmptyString } from "italia-ts-commons/lib/strings";
 import {
   checkSourceIpForHandler,
   clientIPAndCidrTuple as ipTuple
-} from "io-functions-commons/dist/src/utils/source_ip_check";
+} from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
-import { NotificationModel } from "io-functions-commons/dist/src/models/notification";
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
+import { NotificationModel } from "@pagopa/io-functions-commons/dist/src/models/notification";
+import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
 
 import { BlobService } from "azure-storage";
 
-import { MessageModel } from "io-functions-commons/dist/src/models/message";
+import { MessageModel } from "@pagopa/io-functions-commons/dist/src/models/message";
 
 import { isLeft } from "fp-ts/lib/Either";
 import { isNone } from "fp-ts/lib/Option";
 
-import { MessageStatusModel } from "io-functions-commons/dist/src/models/message_status";
-import { NotificationStatusModel } from "io-functions-commons/dist/src/models/notification_status";
+import { MessageStatusModel } from "@pagopa/io-functions-commons/dist/src/models/message_status";
+import { NotificationStatusModel } from "@pagopa/io-functions-commons/dist/src/models/notification_status";
 
 import {
   getMessageNotificationStatuses,
   retrievedMessageToPublic
-} from "io-functions-commons/dist/src/utils/messages";
+} from "@pagopa/io-functions-commons/dist/src/utils/messages";
 
 import { Context } from "@azure/functions";
-import { MessageResponseWithContent } from "io-functions-commons/dist/generated/definitions/MessageResponseWithContent";
-import { MessageResponseWithoutContent } from "io-functions-commons/dist/generated/definitions/MessageResponseWithoutContent";
-import { MessageStatusValueEnum } from "io-functions-commons/dist/generated/definitions/MessageStatusValue";
-import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { MessageResponseWithContent } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageResponseWithContent";
+import { MessageResponseWithoutContent } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageResponseWithoutContent";
+import { MessageStatusValueEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageStatusValue";
+import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 
 /**

--- a/GetMessage/index.ts
+++ b/GetMessage/index.ts
@@ -7,28 +7,28 @@ import { cosmosdbInstance } from "../utils/cosmosdb";
 import {
   MESSAGE_COLLECTION_NAME,
   MessageModel
-} from "io-functions-commons/dist/src/models/message";
+} from "@pagopa/io-functions-commons/dist/src/models/message";
 import {
   SERVICE_COLLECTION_NAME,
   ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
-import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+} from "@pagopa/io-functions-commons/dist/src/models/service";
+import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
+import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
 import {
   MESSAGE_STATUS_COLLECTION_NAME,
   MessageStatusModel
-} from "io-functions-commons/dist/src/models/message_status";
+} from "@pagopa/io-functions-commons/dist/src/models/message_status";
 import {
   NOTIFICATION_COLLECTION_NAME,
   NotificationModel
-} from "io-functions-commons/dist/src/models/notification";
+} from "@pagopa/io-functions-commons/dist/src/models/notification";
 import {
   NOTIFICATION_STATUS_COLLECTION_NAME,
   NotificationStatusModel
-} from "io-functions-commons/dist/src/models/notification_status";
+} from "@pagopa/io-functions-commons/dist/src/models/notification_status";
 
 import { GetMessage } from "./handler";
 

--- a/GetService/__tests__/handler.test.ts
+++ b/GetService/__tests__/handler.test.ts
@@ -6,8 +6,8 @@
 import {
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
-import { IAzureUserAttributes } from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+import { IAzureUserAttributes } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 
 import { NonNegativeInteger } from "italia-ts-commons/lib/numbers";
 import {
@@ -16,9 +16,9 @@ import {
   OrganizationFiscalCode
 } from "italia-ts-commons/lib/strings";
 
-import { toAuthorizedCIDRs } from "io-functions-commons/dist/src/models/service";
+import { toAuthorizedCIDRs } from "@pagopa/io-functions-commons/dist/src/models/service";
 
-import { MaxAllowedPaymentAmount } from "io-functions-commons/dist/generated/definitions/MaxAllowedPaymentAmount";
+import { MaxAllowedPaymentAmount } from "@pagopa/io-functions-commons/dist/generated/definitions/MaxAllowedPaymentAmount";
 
 import { left, right } from "fp-ts/lib/Either";
 import * as reporters from "italia-ts-commons/lib/reporters";

--- a/GetService/handler.ts
+++ b/GetService/handler.ts
@@ -3,23 +3,23 @@ import * as express from "express";
 import {
   ClientIp,
   ClientIpMiddleware
-} from "io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
 
-import { RequiredParamMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_param";
+import { RequiredParamMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_param";
 
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 import {
   AzureUserAttributesMiddleware,
   IAzureUserAttributes
-} from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 import {
   withRequestMiddlewares,
   wrapRequestHandler
-} from "io-functions-commons/dist/src/utils/request_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
 import {
   IResponseSuccessJson,
   ResponseSuccessJson
@@ -29,13 +29,13 @@ import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import {
   checkSourceIpForHandler,
   clientIPAndCidrTuple as ipTuple
-} from "io-functions-commons/dist/src/utils/source_ip_check";
+} from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
 import { Context } from "@azure/functions";
 import { identity } from "fp-ts/lib/function";
 import { TaskEither } from "fp-ts/lib/TaskEither";
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
-import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
+import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { APIClient } from "../clients/admin";
 import { Service } from "../generated/api-admin/Service";
 import { SubscriptionKeys } from "../generated/api-admin/SubscriptionKeys";

--- a/GetService/handler.ts
+++ b/GetService/handler.ts
@@ -32,10 +32,10 @@ import {
 } from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
 import { Context } from "@azure/functions";
-import { identity } from "fp-ts/lib/function";
-import { TaskEither } from "fp-ts/lib/TaskEither";
 import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
 import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { identity } from "fp-ts/lib/function";
+import { TaskEither } from "fp-ts/lib/TaskEither";
 import { APIClient } from "../clients/admin";
 import { Service } from "../generated/api-admin/Service";
 import { SubscriptionKeys } from "../generated/api-admin/SubscriptionKeys";

--- a/GetService/index.ts
+++ b/GetService/index.ts
@@ -6,9 +6,9 @@ import { cosmosdbInstance } from "../utils/cosmosdb";
 import {
   SERVICE_COLLECTION_NAME,
   ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
-import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+} from "@pagopa/io-functions-commons/dist/src/models/service";
+import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
+import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 

--- a/GetSubscriptionsFeed/__tests__/handler.test.ts
+++ b/GetSubscriptionsFeed/__tests__/handler.test.ts
@@ -7,7 +7,7 @@ import { TableService } from "azure-storage";
 import * as dateFmt from "date-fns";
 import * as endOfTomorrow from "date-fns/end_of_tomorrow";
 import * as startOfYesterday from "date-fns/start_of_yesterday";
-import { ServiceId } from "io-functions-commons/dist/generated/definitions/ServiceId";
+import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
 import { FiscalCodeHash } from "../../generated/definitions/FiscalCodeHash";
 import { GetSubscriptionsFeedHandler } from "../handler";
 

--- a/GetSubscriptionsFeed/handler.ts
+++ b/GetSubscriptionsFeed/handler.ts
@@ -5,25 +5,25 @@ import * as t from "io-ts";
 import {
   ClientIp,
   ClientIpMiddleware
-} from "io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
 
-import { RequiredParamMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_param";
+import { RequiredParamMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_param";
 
-import { IResponseErrorQuery } from "io-functions-commons/dist/src/utils/response";
+import { IResponseErrorQuery } from "@pagopa/io-functions-commons/dist/src/utils/response";
 
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 import {
   AzureUserAttributesMiddleware,
   IAzureUserAttributes
-} from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 import {
   withRequestMiddlewares,
   wrapRequestHandler
-} from "io-functions-commons/dist/src/utils/request_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
 import {
   IResponseErrorForbiddenNotAuthorized,
   IResponseErrorInternal,
@@ -38,9 +38,9 @@ import { PatternString } from "italia-ts-commons/lib/strings";
 import {
   checkSourceIpForHandler,
   clientIPAndCidrTuple as ipTuple
-} from "io-functions-commons/dist/src/utils/source_ip_check";
+} from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
+import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
 
 import { TableService } from "azure-storage";
 

--- a/GetSubscriptionsFeed/index.ts
+++ b/GetSubscriptionsFeed/index.ts
@@ -7,9 +7,9 @@ import * as express from "express";
 import {
   SERVICE_COLLECTION_NAME,
   ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
-import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+} from "@pagopa/io-functions-commons/dist/src/models/service";
+import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
+import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { cosmosdbInstance } from "../utils/cosmosdb";
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";

--- a/GetUserServices/__tests__/handler.test.ts
+++ b/GetUserServices/__tests__/handler.test.ts
@@ -6,8 +6,8 @@
 import {
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
-import { IAzureUserAttributes } from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+import { IAzureUserAttributes } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 
 import { NonNegativeInteger } from "italia-ts-commons/lib/numbers";
 import {
@@ -16,9 +16,9 @@ import {
   OrganizationFiscalCode
 } from "italia-ts-commons/lib/strings";
 
-import { toAuthorizedCIDRs } from "io-functions-commons/dist/src/models/service";
+import { toAuthorizedCIDRs } from "@pagopa/io-functions-commons/dist/src/models/service";
 
-import { MaxAllowedPaymentAmount } from "io-functions-commons/dist/generated/definitions/MaxAllowedPaymentAmount";
+import { MaxAllowedPaymentAmount } from "@pagopa/io-functions-commons/dist/generated/definitions/MaxAllowedPaymentAmount";
 
 import { left, right } from "fp-ts/lib/Either";
 import * as reporters from "italia-ts-commons/lib/reporters";

--- a/GetUserServices/handler.ts
+++ b/GetUserServices/handler.ts
@@ -3,21 +3,21 @@ import * as express from "express";
 import {
   ClientIp,
   ClientIpMiddleware
-} from "io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
 
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 import {
   AzureUserAttributesMiddleware,
   IAzureUserAttributes
-} from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 import {
   withRequestMiddlewares,
   wrapRequestHandler
-} from "io-functions-commons/dist/src/utils/request_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
 import {
   IResponseSuccessJson,
   ResponseSuccessJson
@@ -27,14 +27,14 @@ import { EmailString, NonEmptyString } from "italia-ts-commons/lib/strings";
 import {
   checkSourceIpForHandler,
   clientIPAndCidrTuple as ipTuple
-} from "io-functions-commons/dist/src/utils/source_ip_check";
+} from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
 import { Context } from "@azure/functions";
 import { identity } from "fp-ts/lib/function";
 import { TaskEither } from "fp-ts/lib/TaskEither";
-import { ServiceId } from "io-functions-commons/dist/generated/definitions/ServiceId";
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
-import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
+import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
+import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { APIClient } from "../clients/admin";
 import { UserInfo } from "../generated/api-admin/UserInfo";
 import { ServiceIdCollection } from "../generated/definitions/ServiceIdCollection";

--- a/GetUserServices/handler.ts
+++ b/GetUserServices/handler.ts
@@ -30,11 +30,11 @@ import {
 } from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
 import { Context } from "@azure/functions";
-import { identity } from "fp-ts/lib/function";
-import { TaskEither } from "fp-ts/lib/TaskEither";
 import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
 import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
 import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { identity } from "fp-ts/lib/function";
+import { TaskEither } from "fp-ts/lib/TaskEither";
 import { APIClient } from "../clients/admin";
 import { UserInfo } from "../generated/api-admin/UserInfo";
 import { ServiceIdCollection } from "../generated/definitions/ServiceIdCollection";

--- a/GetUserServices/index.ts
+++ b/GetUserServices/index.ts
@@ -6,9 +6,9 @@ import { cosmosdbInstance } from "../utils/cosmosdb";
 import {
   SERVICE_COLLECTION_NAME,
   ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
-import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+} from "@pagopa/io-functions-commons/dist/src/models/service";
+import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
+import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 

--- a/Info/handler.ts
+++ b/Info/handler.ts
@@ -1,5 +1,5 @@
 import * as express from "express";
-import { wrapRequestHandler } from "io-functions-commons/dist/src/utils/request_middleware";
+import { wrapRequestHandler } from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
 import {
   IResponseErrorInternal,
   IResponseSuccessJson,

--- a/Info/handler.ts
+++ b/Info/handler.ts
@@ -1,5 +1,5 @@
-import * as express from "express";
 import { wrapRequestHandler } from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
+import * as express from "express";
 import {
   IResponseErrorInternal,
   IResponseSuccessJson,

--- a/Info/index.ts
+++ b/Info/index.ts
@@ -1,7 +1,7 @@
 import { AzureFunction, Context } from "@azure/functions";
-import * as express from "express";
 import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
 import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import * as express from "express";
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 import { Info } from "./handler";
 

--- a/Info/index.ts
+++ b/Info/index.ts
@@ -1,7 +1,7 @@
 import { AzureFunction, Context } from "@azure/functions";
 import * as express from "express";
-import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
-import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
+import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 import { Info } from "./handler";
 

--- a/MessageStatusUpdaterActivity/handler.ts
+++ b/MessageStatusUpdaterActivity/handler.ts
@@ -4,11 +4,11 @@ import * as t from "io-ts";
 
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 
-import { MessageStatusValue } from "io-functions-commons/dist/generated/definitions/MessageStatusValue";
+import { MessageStatusValue } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageStatusValue";
 import {
   getMessageStatusUpdater,
   MessageStatusModel
-} from "io-functions-commons/dist/src/models/message_status";
+} from "@pagopa/io-functions-commons/dist/src/models/message_status";
 import { ReadableReporter } from "italia-ts-commons/lib/reporters";
 
 export const Input = t.interface({

--- a/MessageStatusUpdaterActivity/index.ts
+++ b/MessageStatusUpdaterActivity/index.ts
@@ -2,7 +2,7 @@ import { AzureFunction } from "@azure/functions";
 import {
   MESSAGE_STATUS_COLLECTION_NAME,
   MessageStatusModel
-} from "io-functions-commons/dist/src/models/message_status";
+} from "@pagopa/io-functions-commons/dist/src/models/message_status";
 
 import { cosmosdbInstance } from "../utils/cosmosdb";
 import { getMessageStatusUpdaterActivityHandler } from "./handler";

--- a/NotificationStatusUpdaterActivity/handler.ts
+++ b/NotificationStatusUpdaterActivity/handler.ts
@@ -4,12 +4,12 @@ import { Context } from "@azure/functions";
 
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 
-import { NotificationChannel } from "io-functions-commons/dist/generated/definitions/NotificationChannel";
-import { NotificationChannelStatusValue } from "io-functions-commons/dist/generated/definitions/NotificationChannelStatusValue";
+import { NotificationChannel } from "@pagopa/io-functions-commons/dist/generated/definitions/NotificationChannel";
+import { NotificationChannelStatusValue } from "@pagopa/io-functions-commons/dist/generated/definitions/NotificationChannelStatusValue";
 import {
   getNotificationStatusUpdater,
   NotificationStatusModel
-} from "io-functions-commons/dist/src/models/notification_status";
+} from "@pagopa/io-functions-commons/dist/src/models/notification_status";
 import { ReadableReporter } from "italia-ts-commons/lib/reporters";
 
 type INotificationStatusUpdaterResult =

--- a/NotificationStatusUpdaterActivity/index.ts
+++ b/NotificationStatusUpdaterActivity/index.ts
@@ -15,7 +15,7 @@ import { AzureFunction } from "@azure/functions";
 import {
   NOTIFICATION_STATUS_COLLECTION_NAME,
   NotificationStatusModel
-} from "io-functions-commons/dist/src/models/notification_status";
+} from "@pagopa/io-functions-commons/dist/src/models/notification_status";
 import { cosmosdbInstance } from "../utils/cosmosdb";
 import { getNotificationStatusUpdaterActivityHandler } from "./handler";
 

--- a/RegenerateServiceKey/__tests__/handler.test.ts
+++ b/RegenerateServiceKey/__tests__/handler.test.ts
@@ -6,8 +6,8 @@
 import {
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
-import { IAzureUserAttributes } from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+import { IAzureUserAttributes } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 
 import { NonNegativeInteger } from "italia-ts-commons/lib/numbers";
 import {
@@ -16,9 +16,9 @@ import {
   OrganizationFiscalCode
 } from "italia-ts-commons/lib/strings";
 
-import { toAuthorizedCIDRs } from "io-functions-commons/dist/src/models/service";
+import { toAuthorizedCIDRs } from "@pagopa/io-functions-commons/dist/src/models/service";
 
-import { MaxAllowedPaymentAmount } from "io-functions-commons/dist/generated/definitions/MaxAllowedPaymentAmount";
+import { MaxAllowedPaymentAmount } from "@pagopa/io-functions-commons/dist/generated/definitions/MaxAllowedPaymentAmount";
 
 import { left, right } from "fp-ts/lib/Either";
 import * as reporters from "italia-ts-commons/lib/reporters";

--- a/RegenerateServiceKey/handler.ts
+++ b/RegenerateServiceKey/handler.ts
@@ -36,11 +36,11 @@ import {
 } from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
 import { Context } from "@azure/functions";
-import { identity } from "fp-ts/lib/function";
-import { TaskEither } from "fp-ts/lib/TaskEither";
 import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
 import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { RequiredBodyPayloadMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_body_payload";
+import { identity } from "fp-ts/lib/function";
+import { TaskEither } from "fp-ts/lib/TaskEither";
 import { APIClient } from "../clients/admin";
 import { SubscriptionKeys } from "../generated/definitions/SubscriptionKeys";
 import { SubscriptionKeyTypePayload } from "../generated/definitions/SubscriptionKeyTypePayload";

--- a/RegenerateServiceKey/handler.ts
+++ b/RegenerateServiceKey/handler.ts
@@ -3,23 +3,23 @@ import * as express from "express";
 import {
   ClientIp,
   ClientIpMiddleware
-} from "io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
 
-import { RequiredParamMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_param";
+import { RequiredParamMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_param";
 
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 import {
   AzureUserAttributesMiddleware,
   IAzureUserAttributes
-} from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 import {
   withRequestMiddlewares,
   wrapRequestHandler
-} from "io-functions-commons/dist/src/utils/request_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
 import {
   IResponseErrorForbiddenNotAuthorized,
   IResponseErrorInternal,
@@ -33,14 +33,14 @@ import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import {
   checkSourceIpForHandler,
   clientIPAndCidrTuple as ipTuple
-} from "io-functions-commons/dist/src/utils/source_ip_check";
+} from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
 import { Context } from "@azure/functions";
 import { identity } from "fp-ts/lib/function";
 import { TaskEither } from "fp-ts/lib/TaskEither";
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
-import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
-import { RequiredBodyPayloadMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_body_payload";
+import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
+import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { RequiredBodyPayloadMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_body_payload";
 import { APIClient } from "../clients/admin";
 import { SubscriptionKeys } from "../generated/definitions/SubscriptionKeys";
 import { SubscriptionKeyTypePayload } from "../generated/definitions/SubscriptionKeyTypePayload";

--- a/RegenerateServiceKey/index.ts
+++ b/RegenerateServiceKey/index.ts
@@ -5,9 +5,9 @@ import { cosmosdbInstance } from "../utils/cosmosdb";
 import {
   SERVICE_COLLECTION_NAME,
   ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
-import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+} from "@pagopa/io-functions-commons/dist/src/models/service";
+import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
+import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 

--- a/StoreMessageContentActivity/handler.ts
+++ b/StoreMessageContentActivity/handler.ts
@@ -7,13 +7,13 @@ import { fromNullable, isNone } from "fp-ts/lib/Option";
 import {
   BlockedInboxOrChannel,
   BlockedInboxOrChannelEnum
-} from "io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
-import { CreatedMessageEvent } from "io-functions-commons/dist/src/models/created_message_event";
-import { MessageModel } from "io-functions-commons/dist/src/models/message";
+} from "@pagopa/io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
+import { CreatedMessageEvent } from "@pagopa/io-functions-commons/dist/src/models/created_message_event";
+import { MessageModel } from "@pagopa/io-functions-commons/dist/src/models/message";
 import {
   ProfileModel,
   RetrievedProfile
-} from "io-functions-commons/dist/src/models/profile";
+} from "@pagopa/io-functions-commons/dist/src/models/profile";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 
 export const SuccessfulStoreMessageContentActivityResult = t.interface({

--- a/StoreMessageContentActivity/handler.ts
+++ b/StoreMessageContentActivity/handler.ts
@@ -1,9 +1,6 @@
 import * as t from "io-ts";
 
 import { Context } from "@azure/functions";
-import { BlobService } from "azure-storage";
-import { isLeft } from "fp-ts/lib/Either";
-import { fromNullable, isNone } from "fp-ts/lib/Option";
 import {
   BlockedInboxOrChannel,
   BlockedInboxOrChannelEnum
@@ -14,6 +11,9 @@ import {
   ProfileModel,
   RetrievedProfile
 } from "@pagopa/io-functions-commons/dist/src/models/profile";
+import { BlobService } from "azure-storage";
+import { isLeft } from "fp-ts/lib/Either";
+import { fromNullable, isNone } from "fp-ts/lib/Option";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 
 export const SuccessfulStoreMessageContentActivityResult = t.interface({

--- a/StoreMessageContentActivity/index.ts
+++ b/StoreMessageContentActivity/index.ts
@@ -5,11 +5,11 @@ import { cosmosdbInstance } from "../utils/cosmosdb";
 import {
   MESSAGE_COLLECTION_NAME,
   MessageModel
-} from "io-functions-commons/dist/src/models/message";
+} from "@pagopa/io-functions-commons/dist/src/models/message";
 import {
   PROFILE_COLLECTION_NAME,
   ProfileModel
-} from "io-functions-commons/dist/src/models/profile";
+} from "@pagopa/io-functions-commons/dist/src/models/profile";
 import { getStoreMessageContentActivityHandler } from "./handler";
 
 import { getConfigOrThrow } from "../utils/config";

--- a/UpdateService/__tests__/handler.test.ts
+++ b/UpdateService/__tests__/handler.test.ts
@@ -6,8 +6,8 @@
 import {
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
-import { IAzureUserAttributes } from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+import { IAzureUserAttributes } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 
 import { NonNegativeInteger } from "italia-ts-commons/lib/numbers";
 import {
@@ -16,12 +16,12 @@ import {
   OrganizationFiscalCode
 } from "italia-ts-commons/lib/strings";
 
-import { ServiceMetadata } from "io-functions-commons/dist/src/models/service";
+import { ServiceMetadata } from "@pagopa/io-functions-commons/dist/src/models/service";
 
-import { MaxAllowedPaymentAmount } from "io-functions-commons/dist/generated/definitions/MaxAllowedPaymentAmount";
+import { MaxAllowedPaymentAmount } from "@pagopa/io-functions-commons/dist/generated/definitions/MaxAllowedPaymentAmount";
 
 import { left, right } from "fp-ts/lib/Either";
-import { ServiceScopeEnum } from "io-functions-commons/dist/generated/definitions/ServiceScope";
+import { ServiceScopeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceScope";
 import * as reporters from "italia-ts-commons/lib/reporters";
 import { Service } from "../../generated/api-admin/Service";
 import { Subscription } from "../../generated/api-admin/Subscription";

--- a/UpdateService/handler.ts
+++ b/UpdateService/handler.ts
@@ -34,11 +34,11 @@ import {
 } from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
 import { Context } from "@azure/functions";
-import { identity } from "fp-ts/lib/function";
-import { TaskEither } from "fp-ts/lib/TaskEither";
 import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
 import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { RequiredParamMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_param";
+import { identity } from "fp-ts/lib/function";
+import { TaskEither } from "fp-ts/lib/TaskEither";
 import { initAppInsights } from "italia-ts-commons/lib/appinsights";
 import { EmailString, NonEmptyString } from "italia-ts-commons/lib/strings";
 import { APIClient } from "../clients/admin";

--- a/UpdateService/handler.ts
+++ b/UpdateService/handler.ts
@@ -3,22 +3,22 @@ import * as express from "express";
 import {
   ClientIp,
   ClientIpMiddleware
-} from "io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
 
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 import {
   AzureUserAttributesMiddleware,
   IAzureUserAttributes
-} from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
-import { RequiredBodyPayloadMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_body_payload";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+import { RequiredBodyPayloadMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_body_payload";
 import {
   withRequestMiddlewares,
   wrapRequestHandler
-} from "io-functions-commons/dist/src/utils/request_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
 import {
   IResponseErrorForbiddenNotAuthorized,
   IResponseErrorInternal,
@@ -31,14 +31,14 @@ import {
 import {
   checkSourceIpForHandler,
   clientIPAndCidrTuple as ipTuple
-} from "io-functions-commons/dist/src/utils/source_ip_check";
+} from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
 import { Context } from "@azure/functions";
 import { identity } from "fp-ts/lib/function";
 import { TaskEither } from "fp-ts/lib/TaskEither";
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
-import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
-import { RequiredParamMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_param";
+import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
+import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { RequiredParamMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_param";
 import { initAppInsights } from "italia-ts-commons/lib/appinsights";
 import { EmailString, NonEmptyString } from "italia-ts-commons/lib/strings";
 import { APIClient } from "../clients/admin";

--- a/UpdateService/index.ts
+++ b/UpdateService/index.ts
@@ -6,9 +6,9 @@ import { cosmosdbInstance } from "../utils/cosmosdb";
 import {
   SERVICE_COLLECTION_NAME,
   ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
-import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+} from "@pagopa/io-functions-commons/dist/src/models/service";
+import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
+import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 

--- a/UploadOrganizationLogo/__tests__/handler.test.ts
+++ b/UploadOrganizationLogo/__tests__/handler.test.ts
@@ -6,8 +6,8 @@
 import {
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
-import { IAzureUserAttributes } from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+import { IAzureUserAttributes } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 
 import { NonNegativeInteger } from "italia-ts-commons/lib/numbers";
 import {
@@ -16,9 +16,9 @@ import {
   OrganizationFiscalCode
 } from "italia-ts-commons/lib/strings";
 
-import { toAuthorizedCIDRs } from "io-functions-commons/dist/src/models/service";
+import { toAuthorizedCIDRs } from "@pagopa/io-functions-commons/dist/src/models/service";
 
-import { MaxAllowedPaymentAmount } from "io-functions-commons/dist/generated/definitions/MaxAllowedPaymentAmount";
+import { MaxAllowedPaymentAmount } from "@pagopa/io-functions-commons/dist/generated/definitions/MaxAllowedPaymentAmount";
 
 import { left, right } from "fp-ts/lib/Either";
 import * as reporters from "italia-ts-commons/lib/reporters";

--- a/UploadOrganizationLogo/handler.ts
+++ b/UploadOrganizationLogo/handler.ts
@@ -35,11 +35,11 @@ import {
 } from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
 import { Context } from "@azure/functions";
-import { identity } from "fp-ts/lib/function";
-import { TaskEither } from "fp-ts/lib/TaskEither";
 import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
 import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { RequiredBodyPayloadMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_body_payload";
+import { identity } from "fp-ts/lib/function";
+import { TaskEither } from "fp-ts/lib/TaskEither";
 import { APIClient } from "../clients/admin";
 import { Logo } from "../generated/api-admin/Logo";
 import { withApiRequestWrapper } from "../utils/api";

--- a/UploadOrganizationLogo/handler.ts
+++ b/UploadOrganizationLogo/handler.ts
@@ -3,23 +3,23 @@ import * as express from "express";
 import {
   ClientIp,
   ClientIpMiddleware
-} from "io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
 
-import { RequiredParamMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_param";
+import { RequiredParamMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_param";
 
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 import {
   AzureUserAttributesMiddleware,
   IAzureUserAttributes
-} from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 import {
   withRequestMiddlewares,
   wrapRequestHandler
-} from "io-functions-commons/dist/src/utils/request_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
 import {
   IResponseErrorForbiddenNotAuthorized,
   IResponseErrorInternal,
@@ -32,14 +32,14 @@ import { OrganizationFiscalCode } from "italia-ts-commons/lib/strings";
 import {
   checkSourceIpForHandler,
   clientIPAndCidrTuple as ipTuple
-} from "io-functions-commons/dist/src/utils/source_ip_check";
+} from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
 import { Context } from "@azure/functions";
 import { identity } from "fp-ts/lib/function";
 import { TaskEither } from "fp-ts/lib/TaskEither";
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
-import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
-import { RequiredBodyPayloadMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_body_payload";
+import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
+import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { RequiredBodyPayloadMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_body_payload";
 import { APIClient } from "../clients/admin";
 import { Logo } from "../generated/api-admin/Logo";
 import { withApiRequestWrapper } from "../utils/api";

--- a/UploadOrganizationLogo/index.ts
+++ b/UploadOrganizationLogo/index.ts
@@ -5,9 +5,9 @@ import { cosmosdbInstance } from "../utils/cosmosdb";
 import {
   SERVICE_COLLECTION_NAME,
   ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
-import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+} from "@pagopa/io-functions-commons/dist/src/models/service";
+import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
+import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 

--- a/UploadServiceLogo/__tests__/handler.test.ts
+++ b/UploadServiceLogo/__tests__/handler.test.ts
@@ -6,8 +6,8 @@
 import {
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
-import { IAzureUserAttributes } from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+import { IAzureUserAttributes } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 
 import { NonNegativeInteger } from "italia-ts-commons/lib/numbers";
 import {
@@ -16,9 +16,9 @@ import {
   OrganizationFiscalCode
 } from "italia-ts-commons/lib/strings";
 
-import { toAuthorizedCIDRs } from "io-functions-commons/dist/src/models/service";
+import { toAuthorizedCIDRs } from "@pagopa/io-functions-commons/dist/src/models/service";
 
-import { MaxAllowedPaymentAmount } from "io-functions-commons/dist/generated/definitions/MaxAllowedPaymentAmount";
+import { MaxAllowedPaymentAmount } from "@pagopa/io-functions-commons/dist/generated/definitions/MaxAllowedPaymentAmount";
 
 import { left, right } from "fp-ts/lib/Either";
 import * as reporters from "italia-ts-commons/lib/reporters";

--- a/UploadServiceLogo/handler.ts
+++ b/UploadServiceLogo/handler.ts
@@ -36,11 +36,11 @@ import {
 } from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
 import { Context } from "@azure/functions";
-import { identity } from "fp-ts/lib/function";
-import { TaskEither } from "fp-ts/lib/TaskEither";
 import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
 import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { RequiredBodyPayloadMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_body_payload";
+import { identity } from "fp-ts/lib/function";
+import { TaskEither } from "fp-ts/lib/TaskEither";
 import { APIClient } from "../clients/admin";
 import { Logo } from "../generated/api-admin/Logo";
 import { withApiRequestWrapper } from "../utils/api";

--- a/UploadServiceLogo/handler.ts
+++ b/UploadServiceLogo/handler.ts
@@ -3,23 +3,23 @@ import * as express from "express";
 import {
   ClientIp,
   ClientIpMiddleware
-} from "io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
 
-import { RequiredParamMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_param";
+import { RequiredParamMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_param";
 
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
   UserGroup
-} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 import {
   AzureUserAttributesMiddleware,
   IAzureUserAttributes
-} from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 import {
   withRequestMiddlewares,
   wrapRequestHandler
-} from "io-functions-commons/dist/src/utils/request_middleware";
+} from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
 import {
   IResponseErrorForbiddenNotAuthorized,
   IResponseErrorInternal,
@@ -33,14 +33,14 @@ import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import {
   checkSourceIpForHandler,
   clientIPAndCidrTuple as ipTuple
-} from "io-functions-commons/dist/src/utils/source_ip_check";
+} from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
 import { Context } from "@azure/functions";
 import { identity } from "fp-ts/lib/function";
 import { TaskEither } from "fp-ts/lib/TaskEither";
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
-import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
-import { RequiredBodyPayloadMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_body_payload";
+import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
+import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { RequiredBodyPayloadMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_body_payload";
 import { APIClient } from "../clients/admin";
 import { Logo } from "../generated/api-admin/Logo";
 import { withApiRequestWrapper } from "../utils/api";

--- a/UploadServiceLogo/index.ts
+++ b/UploadServiceLogo/index.ts
@@ -5,9 +5,9 @@ import { cosmosdbInstance } from "../utils/cosmosdb";
 import {
   SERVICE_COLLECTION_NAME,
   ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
-import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+} from "@pagopa/io-functions-commons/dist/src/models/service";
+import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
+import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 

--- a/WebhookNotificationActivity/__tests__/handler.test.ts
+++ b/WebhookNotificationActivity/__tests__/handler.test.ts
@@ -14,11 +14,11 @@ import {
   OrganizationFiscalCode
 } from "italia-ts-commons/lib/strings";
 
-import { CreatedMessageEventSenderMetadata } from "io-functions-commons/dist/src/models/created_message_sender_metadata";
-import { Notification } from "io-functions-commons/dist/src/models/notification";
-import { isTransientError } from "io-functions-commons/dist/src/utils/errors";
+import { CreatedMessageEventSenderMetadata } from "@pagopa/io-functions-commons/dist/src/models/created_message_sender_metadata";
+import { Notification } from "@pagopa/io-functions-commons/dist/src/models/notification";
+import { isTransientError } from "@pagopa/io-functions-commons/dist/src/utils/errors";
 
-import { NotificationEvent } from "io-functions-commons/dist/src/models/notification_event";
+import { NotificationEvent } from "@pagopa/io-functions-commons/dist/src/models/notification_event";
 
 import { readableReport } from "italia-ts-commons/lib/reporters";
 
@@ -27,12 +27,12 @@ import {
   sendToWebhook
 } from "../handler";
 
-import { HttpsUrl } from "io-functions-commons/dist/generated/definitions/HttpsUrl";
-import { MessageBodyMarkdown } from "io-functions-commons/dist/generated/definitions/MessageBodyMarkdown";
-import { MessageContent } from "io-functions-commons/dist/generated/definitions/MessageContent";
-import { MessageSubject } from "io-functions-commons/dist/generated/definitions/MessageSubject";
-import { NotificationChannelEnum } from "io-functions-commons/dist/generated/definitions/NotificationChannel";
-import { TimeToLiveSeconds } from "io-functions-commons/dist/generated/definitions/TimeToLiveSeconds";
+import { HttpsUrl } from "@pagopa/io-functions-commons/dist/generated/definitions/HttpsUrl";
+import { MessageBodyMarkdown } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageBodyMarkdown";
+import { MessageContent } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageContent";
+import { MessageSubject } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageSubject";
+import { NotificationChannelEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/NotificationChannel";
+import { TimeToLiveSeconds } from "@pagopa/io-functions-commons/dist/generated/definitions/TimeToLiveSeconds";
 import { getNotifyClient } from "../client";
 
 import { agent } from "italia-ts-commons";

--- a/WebhookNotificationActivity/client.ts
+++ b/WebhookNotificationActivity/client.ts
@@ -1,4 +1,4 @@
-import { HttpsUrl } from "io-functions-commons/dist/generated/definitions/HttpsUrl";
+import { HttpsUrl } from "@pagopa/io-functions-commons/dist/generated/definitions/HttpsUrl";
 import {
   ApiHeaderJson,
   createFetchRequestForApi,

--- a/WebhookNotificationActivity/handler.ts
+++ b/WebhookNotificationActivity/handler.ts
@@ -17,25 +17,25 @@ import { Context } from "@azure/functions";
 import {
   NotificationModel,
   WebhookNotification
-} from "io-functions-commons/dist/src/models/notification";
-import { NotificationEvent } from "io-functions-commons/dist/src/models/notification_event";
+} from "@pagopa/io-functions-commons/dist/src/models/notification";
+import { NotificationEvent } from "@pagopa/io-functions-commons/dist/src/models/notification_event";
 
 import {
   isTransientError,
   PermanentError,
   RuntimeError,
   TransientError
-} from "io-functions-commons/dist/src/utils/errors";
+} from "@pagopa/io-functions-commons/dist/src/utils/errors";
 
-import { CreatedMessageEventSenderMetadata } from "io-functions-commons/dist/src/models/created_message_sender_metadata";
+import { CreatedMessageEventSenderMetadata } from "@pagopa/io-functions-commons/dist/src/models/created_message_sender_metadata";
 import {
   ActiveMessage,
   NewMessageWithoutContent
-} from "io-functions-commons/dist/src/models/message";
+} from "@pagopa/io-functions-commons/dist/src/models/message";
 
-import { HttpsUrl } from "io-functions-commons/dist/generated/definitions/HttpsUrl";
-import { MessageContent } from "io-functions-commons/dist/generated/definitions/MessageContent";
-import { SenderMetadata } from "io-functions-commons/dist/generated/definitions/SenderMetadata";
+import { HttpsUrl } from "@pagopa/io-functions-commons/dist/generated/definitions/HttpsUrl";
+import { MessageContent } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageContent";
+import { SenderMetadata } from "@pagopa/io-functions-commons/dist/generated/definitions/SenderMetadata";
 
 import { fromEither, TaskEither, tryCatch } from "fp-ts/lib/TaskEither";
 import {

--- a/WebhookNotificationActivity/index.ts
+++ b/WebhookNotificationActivity/index.ts
@@ -2,7 +2,7 @@ import { AzureFunction } from "@azure/functions";
 import {
   NOTIFICATION_COLLECTION_NAME,
   NotificationModel
-} from "io-functions-commons/dist/src/models/notification";
+} from "@pagopa/io-functions-commons/dist/src/models/notification";
 import { cosmosdbInstance } from "../utils/cosmosdb";
 
 import { agent } from "italia-ts-commons";

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.13.1",
   "license": "MIT",
   "scripts": {
-    "prebuild": "npm run generate",
+    "prebuild": "shx rm -rf dist && yarn generate",
     "build": "tsc",
     "build:production": "npm run prestart && yarn install --production",
     "postbuild": "dependency-check package.json --no-dev --missing ./dist/**/*.js",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@azure/cosmos": "^3.7.2",
+    "@pagopa/io-functions-commons": "^19.2.0",
     "@pagopa/ts-commons": "^9.1.0",
     "applicationinsights": "^1.7.4",
     "azure-storage": "^2.10.3",
@@ -61,7 +62,6 @@
     "express": "^4.15.3",
     "fp-ts": "1.17.4",
     "html-to-text": "^4.0.0",
-    "io-functions-commons": "^17.3.0",
     "io-functions-express": "^0.1.1",
     "io-ts": "1.8.5",
     "italia-ts-commons": "^8.6.0",

--- a/utils/__tests__/arbitraries.ts
+++ b/utils/__tests__/arbitraries.ts
@@ -1,13 +1,13 @@
 import * as assert from "assert";
 import * as fc from "fast-check";
 import { some } from "fp-ts/lib/Option";
-import { BlockedInboxOrChannelEnum } from "io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
-import { NewMessage } from "io-functions-commons/dist/generated/definitions/NewMessage";
-import { PreferredLanguageEnum } from "io-functions-commons/dist/generated/definitions/PreferredLanguage";
-import { NewMessageWithoutContent } from "io-functions-commons/dist/src/models/message";
-import { RetrievedProfile } from "io-functions-commons/dist/src/models/profile";
-import { Service } from "io-functions-commons/dist/src/models/service";
-import { ClientIp } from "io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+import { BlockedInboxOrChannelEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
+import { NewMessage } from "@pagopa/io-functions-commons/dist/generated/definitions/NewMessage";
+import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
+import { NewMessageWithoutContent } from "@pagopa/io-functions-commons/dist/src/models/message";
+import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/profile";
+import { Service } from "@pagopa/io-functions-commons/dist/src/models/service";
+import { ClientIp } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
 import {
   NonNegativeInteger,
   WithinRangeInteger

--- a/utils/__tests__/arbitraries.ts
+++ b/utils/__tests__/arbitraries.ts
@@ -1,6 +1,3 @@
-import * as assert from "assert";
-import * as fc from "fast-check";
-import { some } from "fp-ts/lib/Option";
 import { BlockedInboxOrChannelEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
 import { NewMessage } from "@pagopa/io-functions-commons/dist/generated/definitions/NewMessage";
 import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
@@ -8,6 +5,9 @@ import { NewMessageWithoutContent } from "@pagopa/io-functions-commons/dist/src/
 import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/profile";
 import { Service } from "@pagopa/io-functions-commons/dist/src/models/service";
 import { ClientIp } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+import * as assert from "assert";
+import * as fc from "fast-check";
+import { some } from "fp-ts/lib/Option";
 import {
   NonNegativeInteger,
   WithinRangeInteger

--- a/utils/__tests__/profile.test.ts
+++ b/utils/__tests__/profile.test.ts
@@ -2,11 +2,11 @@ import * as fc from "fast-check";
 
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 
-import { BlockedInboxOrChannelEnum } from "io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
+import { BlockedInboxOrChannelEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
 
-import { RetrievedProfile } from "io-functions-commons/dist/src/models/profile";
-import { retrievedProfileArb } from "./arbitraries";
+import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/profile";
 import { isSenderAllowed, retrievedProfileToLimitedProfile } from "../profile";
+import { retrievedProfileArb } from "./arbitraries";
 
 describe("isSenderAllowed", () => {
   it("should return false if the service is not allowed to send notifications to the user", () => {

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -5,8 +5,8 @@
  * The configuration is evaluate eagerly at the first access to the module. The module exposes convenient methods to access such value.
  */
 
-import { ServiceId } from "io-functions-commons/dist/generated/definitions/ServiceId";
-import { MailerConfig } from "io-functions-commons/dist/src/mailer";
+import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
+import { MailerConfig } from "@pagopa/io-functions-commons/dist/src/mailer";
 import * as t from "io-ts";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";

--- a/utils/profile.ts
+++ b/utils/profile.ts
@@ -1,8 +1,8 @@
-import { BlockedInboxOrChannelEnum } from "io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
-import { LimitedProfile } from "io-functions-commons/dist/generated/definitions/LimitedProfile";
-import { ServiceId } from "io-functions-commons/dist/generated/definitions/ServiceId";
-import { RetrievedProfile } from "io-functions-commons/dist/src/models/profile";
-import { IRequestMiddleware } from "io-functions-commons/dist/src/utils/request_middleware";
+import { BlockedInboxOrChannelEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
+import { LimitedProfile } from "@pagopa/io-functions-commons/dist/generated/definitions/LimitedProfile";
+import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
+import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/profile";
+import { IRequestMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
 import { ResponseErrorFromValidationErrors } from "italia-ts-commons/lib/responses";
 import { GetLimitedProfileByPOSTPayload } from "../generated/definitions/GetLimitedProfileByPOSTPayload";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -419,6 +419,34 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
+"@pagopa/io-functions-commons@^19.2.0":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-19.2.0.tgz#5614523e861fc8480e2f9b6b51a6faa5e90c00e7"
+  integrity sha512-PpEHqMaTghiM5MhbP2mB/Ez/aCumq2q8UCXxJnHIjzrQjhYRYGeo8Muf05V5WwusOatHA+y8V5+SWFxBVupZoQ==
+  dependencies:
+    "@azure/cosmos" "^3.7.2"
+    "@pagopa/ts-commons" "^9.1.0"
+    applicationinsights "^1.7.3"
+    azure-storage "^2.10.3"
+    cidr-matcher "^2.1.0"
+    fp-ts "1.17.4"
+    helmet "^3.13.0"
+    helmet-csp "^2.5.1"
+    io-functions-express "^0.1.1"
+    io-ts "1.8.5"
+    node-fetch "^2.6.1"
+    nodemailer "^6.4.13"
+    nodemailer-sendgrid "^1.0.3"
+    referrer-policy "^1.1.0"
+    rehype-stringify "^3.0.0"
+    remark-frontmatter "^2.0.0"
+    remark-parse "^5.0.0"
+    remark-rehype "^3.0.0"
+    request-ip "^2.1.3"
+    ulid "^2.3.0"
+    unified "^9.0.0"
+    winston "^3.1.0"
+
 "@pagopa/openapi-codegen-ts@^8.0.0":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@pagopa/openapi-codegen-ts/-/openapi-codegen-ts-8.0.0.tgz#708edb9cee4d299d069e882867c7761ff2669cf0"
@@ -2967,34 +2995,6 @@ invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
-
-io-functions-commons@^17.3.0:
-  version "17.3.0"
-  resolved "https://registry.yarnpkg.com/io-functions-commons/-/io-functions-commons-17.3.0.tgz#4aac0f5ad92df0a3796bfb07c7be2a91a396fbf2"
-  integrity sha512-MiZANOb5daooMHavf9cEIp8Z/dA/yc7UAFM+kl7Gu7jXO3Y+5lHi5bdKElfvSYila5q2QmDcP6zi8SMSnItK3g==
-  dependencies:
-    "@azure/cosmos" "^3.7.2"
-    applicationinsights "^1.7.3"
-    azure-storage "^2.10.3"
-    cidr-matcher "^2.1.0"
-    fp-ts "1.17.4"
-    helmet "^3.13.0"
-    helmet-csp "^2.5.1"
-    io-functions-express "^0.1.1"
-    io-ts "1.8.5"
-    italia-ts-commons "^8.6.0"
-    node-fetch "^2.6.1"
-    nodemailer "^6.4.13"
-    nodemailer-sendgrid "^1.0.3"
-    referrer-policy "^1.1.0"
-    rehype-stringify "^3.0.0"
-    remark-frontmatter "^2.0.0"
-    remark-parse "^5.0.0"
-    remark-rehype "^3.0.0"
-    request-ip "^2.1.3"
-    ulid "^2.3.0"
-    unified "^9.0.0"
-    winston "^3.1.0"
 
 io-functions-express@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
#### List of Changes
- upgrade `io-functions-commons` to `@pagopa/io-functions-commons`

#### Motivation and Context
The new version of `@pagopa/io-functions-commons` fix failure when a Service has an authorized CIDR without a subnet.

#### How Has This Been Tested?
- unit test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
