### PR TITLE
[#ENTE-82] Limit API access for incomplete services

### DIFF
--- a/CreateMessage/__tests__/handler.test.ts
+++ b/CreateMessage/__tests__/handler.test.ts
@@ -270,7 +270,8 @@ describe("CreateMessageHandler", () => {
           undefined as any,
           undefined as any,
           undefined as any,
-          true
+          true,
+          []
         );
 
         const response = await createMessageHandler(
@@ -294,7 +295,8 @@ describe("CreateMessageHandler", () => {
       undefined as any,
       undefined as any,
       undefined as any,
-      true
+      true,
+      []
     );
 
     const response = await createMessageHandler(
@@ -335,7 +337,8 @@ describe("CreateMessageHandler", () => {
       mockTelemetryClient,
       undefined as any,
       mockGenerateObjId,
-      true
+      true,
+      []
     );
 
     const response = await createMessageHandler(

--- a/CreateMessage/__tests__/handler.test.ts
+++ b/CreateMessage/__tests__/handler.test.ts
@@ -269,7 +269,8 @@ describe("CreateMessageHandler", () => {
         const createMessageHandler = CreateMessageHandler(
           undefined as any,
           undefined as any,
-          undefined as any
+          undefined as any,
+          true
         );
 
         const response = await createMessageHandler(
@@ -292,7 +293,8 @@ describe("CreateMessageHandler", () => {
     const createMessageHandler = CreateMessageHandler(
       undefined as any,
       undefined as any,
-      undefined as any
+      undefined as any,
+      true
     );
 
     const response = await createMessageHandler(
@@ -332,7 +334,8 @@ describe("CreateMessageHandler", () => {
     const createMessageHandler = CreateMessageHandler(
       mockTelemetryClient,
       undefined as any,
-      mockGenerateObjId
+      mockGenerateObjId,
+      true
     );
 
     const response = await createMessageHandler(

--- a/CreateMessage/handler.ts
+++ b/CreateMessage/handler.ts
@@ -430,11 +430,10 @@ export function CreateMessageHandler(
           !incompleteServiceWhitelist.includes(serviceId) &&
           !authorizedRecipients.has(fiscalCode)
             ? fromEither(
-                ValidService.decode(userAttributes.service)
-                  .map(_1 => true)
-                  .mapLeft(
-                    _1 => ResponseErrorForbiddenNotAuthorizedForRecipient
-                  )
+                ValidService.decode(userAttributes.service).bimap(
+                  _1 => ResponseErrorForbiddenNotAuthorizedForRecipient,
+                  _1 => true
+                )
               )
             : fromEither(right(true))
         )

--- a/CreateMessage/handler.ts
+++ b/CreateMessage/handler.ts
@@ -337,7 +337,8 @@ const redirectToNewMessage = (
 export function CreateMessageHandler(
   telemetryClient: ReturnType<typeof initAppInsights>,
   messageModel: MessageModel,
-  generateObjectId: ObjectIdGenerator
+  generateObjectId: ObjectIdGenerator,
+  disableIncompleteServices: boolean
 ): ICreateMessageHandler {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   return async (
@@ -423,7 +424,7 @@ export function CreateMessageHandler(
         )
         // Verify if the Service has the required quality to sent message
         .chain(_ =>
-          !authorizedRecipients.has(fiscalCode)
+          disableIncompleteServices && !authorizedRecipients.has(fiscalCode)
             ? fromEither(
                 ValidService.decode(userAttributes.service)
                   .map(_1 => true)
@@ -490,12 +491,14 @@ export function CreateMessageHandler(
 export function CreateMessage(
   telemetryClient: ReturnType<typeof initAppInsights>,
   serviceModel: ServiceModel,
-  messageModel: MessageModel
+  messageModel: MessageModel,
+  disableIncompleteServices: boolean
 ): express.RequestHandler {
   const handler = CreateMessageHandler(
     telemetryClient,
     messageModel,
-    ulidGenerator
+    ulidGenerator,
+    disableIncompleteServices
   );
   const middlewaresWrap = withRequestMiddlewares(
     // extract Azure Functions bindings

--- a/CreateMessage/index.ts
+++ b/CreateMessage/index.ts
@@ -51,7 +51,8 @@ app.post(
     telemetryClient,
     serviceModel,
     messageModel,
-    config.FF_DISABLE_INCOMPLETE_SERVICES
+    config.FF_DISABLE_INCOMPLETE_SERVICES,
+    config.FF_INCOMPLETE_SERVICE_WHITELIST
   )
 );
 

--- a/CreateMessage/index.ts
+++ b/CreateMessage/index.ts
@@ -47,7 +47,12 @@ const telemetryClient = initTelemetryClient(
 
 app.post(
   "/api/v1/messages/:fiscalcode?",
-  CreateMessage(telemetryClient, serviceModel, messageModel)
+  CreateMessage(
+    telemetryClient,
+    serviceModel,
+    messageModel,
+    config.FF_DISABLE_INCOMPLETE_SERVICES
+  )
 );
 
 const azureFunctionHandler = createAzureFunctionHandler(app);

--- a/GetLimitedProfile/__tests__/handler.test.ts
+++ b/GetLimitedProfile/__tests__/handler.test.ts
@@ -52,7 +52,8 @@ describe("GetLimitedProfileHandler", () => {
             findLastVersionByModelId: jest.fn(() => fromLeft({}))
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
-            mockProfileModel
+            mockProfileModel,
+            true
           );
 
           const response = await limitedProfileHandler(
@@ -87,7 +88,8 @@ describe("GetLimitedProfileHandler", () => {
             findLastVersionByModelId: jest.fn(() => taskEither.of(none))
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
-            mockProfileModel
+            mockProfileModel,
+            true
           );
 
           const response = await limitedProfileHandler(
@@ -129,7 +131,8 @@ describe("GetLimitedProfileHandler", () => {
             )
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
-            mockProfileModel
+            mockProfileModel,
+            true
           );
 
           const response = await limitedProfileHandler(
@@ -167,7 +170,8 @@ describe("GetLimitedProfileHandler", () => {
             )
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
-            mockProfileModel
+            mockProfileModel,
+            true
           );
 
           const response = await limitedProfileHandler(
@@ -212,7 +216,8 @@ describe("GetLimitedProfileHandler", () => {
             )
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
-            mockProfileModel
+            mockProfileModel,
+            true
           );
 
           const response = await limitedProfileHandler(
@@ -257,7 +262,8 @@ describe("GetLimitedProfileHandler", () => {
             )
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
-            mockProfileModel
+            mockProfileModel,
+            true
           );
 
           const response = await limitedProfileHandler(
@@ -306,7 +312,8 @@ describe("GetLimitedProfileHandler", () => {
             )
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
-            mockProfileModel
+            mockProfileModel,
+            true
           );
 
           const response = await limitedProfileHandler(

--- a/GetLimitedProfile/__tests__/handler.test.ts
+++ b/GetLimitedProfile/__tests__/handler.test.ts
@@ -53,7 +53,8 @@ describe("GetLimitedProfileHandler", () => {
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
             mockProfileModel,
-            true
+            true,
+            []
           );
 
           const response = await limitedProfileHandler(
@@ -89,7 +90,8 @@ describe("GetLimitedProfileHandler", () => {
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
             mockProfileModel,
-            true
+            true,
+            []
           );
 
           const response = await limitedProfileHandler(
@@ -132,7 +134,8 @@ describe("GetLimitedProfileHandler", () => {
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
             mockProfileModel,
-            true
+            true,
+            []
           );
 
           const response = await limitedProfileHandler(
@@ -171,7 +174,8 @@ describe("GetLimitedProfileHandler", () => {
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
             mockProfileModel,
-            true
+            true,
+            []
           );
 
           const response = await limitedProfileHandler(
@@ -217,7 +221,8 @@ describe("GetLimitedProfileHandler", () => {
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
             mockProfileModel,
-            true
+            true,
+            []
           );
 
           const response = await limitedProfileHandler(
@@ -263,7 +268,8 @@ describe("GetLimitedProfileHandler", () => {
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
             mockProfileModel,
-            true
+            true,
+            []
           );
 
           const response = await limitedProfileHandler(
@@ -313,7 +319,8 @@ describe("GetLimitedProfileHandler", () => {
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
             mockProfileModel,
-            true
+            true,
+            []
           );
 
           const response = await limitedProfileHandler(

--- a/GetLimitedProfile/__tests__/handler.test.ts
+++ b/GetLimitedProfile/__tests__/handler.test.ts
@@ -1,5 +1,4 @@
 import * as fc from "fast-check";
-import { left, right } from "fp-ts/lib/Either";
 import { none, some } from "fp-ts/lib/Option";
 import {
   ProfileModel,
@@ -10,11 +9,7 @@ import {
   UserGroup
 } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 import { IAzureUserAttributes } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
-import {
-  EmailString,
-  FiscalCode,
-  NonEmptyString
-} from "italia-ts-commons/lib/strings";
+import { EmailString, NonEmptyString } from "italia-ts-commons/lib/strings";
 
 import { fromLeft } from "fp-ts/lib/IOEither";
 import { taskEither } from "fp-ts/lib/TaskEither";
@@ -25,6 +20,12 @@ import {
 } from "../../utils/__tests__/arbitraries";
 import { retrievedProfileToLimitedProfile } from "../../utils/profile";
 import { GetLimitedProfileHandler } from "../handler";
+import {
+  aFiscalCode,
+  anIncompleteService,
+  anotherFiscalCode,
+  aValidService
+} from "../../__mocks__/mocks";
 
 // eslint-disable-next-line sonar/sonar-max-lines-per-function
 describe("GetLimitedProfileHandler", () => {
@@ -38,9 +39,7 @@ describe("GetLimitedProfileHandler", () => {
   const mockAzureUserAttributes: IAzureUserAttributes = {
     email: "" as EmailString,
     kind: "IAzureUserAttributes",
-    service: {
-      serviceId: "01234567890"
-    } as IAzureUserAttributes["service"]
+    service: (aValidService as unknown) as IAzureUserAttributes["service"]
   };
 
   it("should respond with ResponseErrorQuery when a database error occurs", async () => {
@@ -181,7 +180,54 @@ describe("GetLimitedProfileHandler", () => {
               ...mockAzureUserAttributes,
               service: {
                 ...mockAzureUserAttributes.service,
-                authorizedRecipients: new Set(["ABC" as FiscalCode])
+                authorizedRecipients: new Set([
+                  aFiscalCode === fiscalCode ? anotherFiscalCode : aFiscalCode
+                ])
+              }
+            },
+            fiscalCode
+          );
+
+          expect(
+            mockProfileModel.findLastVersionByModelId
+          ).not.toHaveBeenCalled();
+          expect(response.kind).toBe(
+            "IResponseErrorForbiddenNotAuthorizedForRecipient"
+          );
+        }
+      )
+    );
+  });
+
+  it("should respond with 403 when the requested profile is found in the db but the service hasn't the required quality field", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        clientIpArb,
+        fiscalCodeArb,
+        retrievedProfileArb,
+        async (clientIp, fiscalCode, retrievedProfile) => {
+          const mockProfileModel = ({
+            findLastVersionByModelId: jest.fn(() =>
+              taskEither.of(some(retrievedProfile))
+            )
+          } as unknown) as ProfileModel;
+          const limitedProfileHandler = GetLimitedProfileHandler(
+            mockProfileModel
+          );
+
+          const response = await limitedProfileHandler(
+            {
+              ...mockAzureApiAuthorization,
+              groups: new Set([UserGroup.ApiMessageWrite])
+            },
+            clientIp,
+            {
+              ...mockAzureUserAttributes,
+              service: {
+                ...anIncompleteService,
+                authorizedRecipients: new Set([
+                  aFiscalCode === fiscalCode ? anotherFiscalCode : aFiscalCode
+                ])
               }
             },
             fiscalCode

--- a/GetLimitedProfile/handler.ts
+++ b/GetLimitedProfile/handler.ts
@@ -1,3 +1,4 @@
+import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
 import { ProfileModel } from "@pagopa/io-functions-commons/dist/src/models/profile";
 import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
 import {
@@ -49,7 +50,8 @@ type IGetLimitedProfileHandler = (
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function GetLimitedProfileHandler(
   profileModel: ProfileModel,
-  disableIncompleteServices: boolean
+  disableIncompleteServices: boolean,
+  incompleteServiceWhitelist: ReadonlyArray<ServiceId>
 ): IGetLimitedProfileHandler {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   return async (auth, __, userAttributes, fiscalCode) =>
@@ -58,7 +60,8 @@ export function GetLimitedProfileHandler(
       userAttributes,
       fiscalCode,
       profileModel,
-      disableIncompleteServices
+      disableIncompleteServices,
+      incompleteServiceWhitelist
     ).run();
 }
 
@@ -69,11 +72,13 @@ export function GetLimitedProfileHandler(
 export function GetLimitedProfile(
   serviceModel: ServiceModel,
   profileModel: ProfileModel,
-  disableIncompleteServices: boolean
+  disableIncompleteServices: boolean,
+  incompleteServiceWhitelist: ReadonlyArray<ServiceId>
 ): express.RequestHandler {
   const handler = GetLimitedProfileHandler(
     profileModel,
-    disableIncompleteServices
+    disableIncompleteServices,
+    incompleteServiceWhitelist
   );
 
   const middlewaresWrap = withRequestMiddlewares(

--- a/GetLimitedProfile/handler.ts
+++ b/GetLimitedProfile/handler.ts
@@ -1,4 +1,3 @@
-import { LimitedProfile } from "@pagopa/io-functions-commons/dist/generated/definitions/LimitedProfile";
 import { ProfileModel } from "@pagopa/io-functions-commons/dist/src/models/profile";
 import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
 import {
@@ -20,30 +19,15 @@ import {
   wrapRequestHandler
 } from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
 import {
-  IResponseErrorQuery,
-  ResponseErrorQuery
-} from "@pagopa/io-functions-commons/dist/src/utils/response";
-import {
   checkSourceIpForHandler,
   clientIPAndCidrTuple as ipTuple
 } from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 import * as express from "express";
-import { isLeft, isRight } from "fp-ts/lib/Either";
-import { isSome } from "fp-ts/lib/Option";
-import {
-  IResponseErrorForbiddenNotAuthorizedForRecipient,
-  IResponseErrorNotFound,
-  IResponseSuccessJson,
-  ResponseErrorForbiddenNotAuthorizedForRecipient,
-  ResponseErrorNotFound,
-  ResponseSuccessJson
-} from "italia-ts-commons/lib/responses";
 import { FiscalCode } from "italia-ts-commons/lib/strings";
 
-import { canWriteMessage } from "../CreateMessage/handler";
 import {
-  isSenderAllowed,
-  retrievedProfileToLimitedProfile
+  getLimitedProfileTask,
+  IGetLimitedProfileResponses
 } from "../utils/profile";
 
 /**
@@ -51,17 +35,13 @@ import {
  *
  * GetLimitedProfile expects a FiscalCode as input and returns a LimitedProfile or a NotFound error.
  */
+
 type IGetLimitedProfileHandler = (
   apiAuthorization: IAzureApiAuthorization,
   clientIp: ClientIp,
   userAttributes: IAzureUserAttributes,
   fiscalCode: FiscalCode
-) => Promise<
-  | IResponseSuccessJson<LimitedProfile>
-  | IResponseErrorNotFound
-  | IResponseErrorQuery
-  | IResponseErrorForbiddenNotAuthorizedForRecipient
->;
+) => Promise<IGetLimitedProfileResponses>;
 
 /**
  * Returns a type safe GetLimitedProfile handler.
@@ -71,57 +51,8 @@ export function GetLimitedProfileHandler(
   profileModel: ProfileModel
 ): IGetLimitedProfileHandler {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  return async (auth, __, userAttributes, fiscalCode) => {
-    // Sandboxed accounts will receive 403
-    // if they're not authorized to send a messages to this fiscal code.
-    // This prevents leaking the information, to sandboxed account,
-    // that the fiscal code belongs to a subscribed user
-    if (
-      isLeft(
-        canWriteMessage(
-          auth.groups,
-          userAttributes.service.authorizedRecipients,
-          fiscalCode
-        )
-      )
-    ) {
-      return ResponseErrorForbiddenNotAuthorizedForRecipient;
-    }
-
-    const maybeProfileOrError = await profileModel
-      .findLastVersionByModelId([fiscalCode])
-      .run();
-
-    if (isRight(maybeProfileOrError)) {
-      const maybeProfile = maybeProfileOrError.value;
-
-      // We also return ResponseErrorNotFound in case the profile is found
-      // but the inbox is not enabled (onboarding not completed).
-      if (isSome(maybeProfile) && maybeProfile.value.isInboxEnabled) {
-        const profile = maybeProfile.value;
-
-        return ResponseSuccessJson(
-          retrievedProfileToLimitedProfile(
-            profile,
-            isSenderAllowed(
-              profile.blockedInboxOrChannels,
-              userAttributes.service.serviceId
-            )
-          )
-        );
-      } else {
-        return ResponseErrorNotFound(
-          "Profile not found",
-          "The profile you requested was not found in the system."
-        );
-      }
-    } else {
-      return ResponseErrorQuery(
-        "Error while retrieving the profile",
-        maybeProfileOrError.value
-      );
-    }
-  };
+  return async (auth, __, userAttributes, fiscalCode) =>
+    getLimitedProfileTask(auth, userAttributes, fiscalCode, profileModel).run();
 }
 
 /**

--- a/GetLimitedProfile/handler.ts
+++ b/GetLimitedProfile/handler.ts
@@ -48,11 +48,18 @@ type IGetLimitedProfileHandler = (
  */
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function GetLimitedProfileHandler(
-  profileModel: ProfileModel
+  profileModel: ProfileModel,
+  disableIncompleteServices: boolean
 ): IGetLimitedProfileHandler {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   return async (auth, __, userAttributes, fiscalCode) =>
-    getLimitedProfileTask(auth, userAttributes, fiscalCode, profileModel).run();
+    getLimitedProfileTask(
+      auth,
+      userAttributes,
+      fiscalCode,
+      profileModel,
+      disableIncompleteServices
+    ).run();
 }
 
 /**
@@ -61,9 +68,13 @@ export function GetLimitedProfileHandler(
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function GetLimitedProfile(
   serviceModel: ServiceModel,
-  profileModel: ProfileModel
+  profileModel: ProfileModel,
+  disableIncompleteServices: boolean
 ): express.RequestHandler {
-  const handler = GetLimitedProfileHandler(profileModel);
+  const handler = GetLimitedProfileHandler(
+    profileModel,
+    disableIncompleteServices
+  );
 
   const middlewaresWrap = withRequestMiddlewares(
     AzureApiAuthMiddleware(new Set([UserGroup.ApiLimitedProfileRead])),

--- a/GetLimitedProfile/index.ts
+++ b/GetLimitedProfile/index.ts
@@ -12,9 +12,12 @@ import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middl
 import cors = require("cors");
 import express = require("express");
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
+import { getConfigOrThrow } from "../utils/config";
 import { cosmosdbInstance } from "../utils/cosmosdb";
 
 import { GetLimitedProfile } from "./handler";
+
+const config = getConfigOrThrow();
 
 // Setup Express
 const app = express();
@@ -33,7 +36,11 @@ const profileModel = new ProfileModel(
 
 app.get(
   "/api/v1/profiles/:fiscalcode",
-  GetLimitedProfile(serviceModel, profileModel)
+  GetLimitedProfile(
+    serviceModel,
+    profileModel,
+    config.FF_DISABLE_INCOMPLETE_SERVICES
+  )
 );
 
 const azureFunctionHandler = createAzureFunctionHandler(app);

--- a/GetLimitedProfile/index.ts
+++ b/GetLimitedProfile/index.ts
@@ -39,7 +39,8 @@ app.get(
   GetLimitedProfile(
     serviceModel,
     profileModel,
-    config.FF_DISABLE_INCOMPLETE_SERVICES
+    config.FF_DISABLE_INCOMPLETE_SERVICES,
+    config.FF_INCOMPLETE_SERVICE_WHITELIST
   )
 );
 

--- a/GetLimitedProfileByPOST/__tests__/handler.test.ts
+++ b/GetLimitedProfileByPOST/__tests__/handler.test.ts
@@ -55,7 +55,8 @@ describe("GetLimitedProfileByPOSTHandler", () => {
             findLastVersionByModelId: jest.fn(() => fromLeft({}))
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
-            mockProfileModel
+            mockProfileModel,
+            true
           );
 
           const response = await limitedProfileHandler(
@@ -90,7 +91,8 @@ describe("GetLimitedProfileByPOSTHandler", () => {
             findLastVersionByModelId: jest.fn(() => taskEither.of(none))
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
-            mockProfileModel
+            mockProfileModel,
+            true
           );
 
           const response = await limitedProfileHandler(
@@ -132,7 +134,8 @@ describe("GetLimitedProfileByPOSTHandler", () => {
             )
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
-            mockProfileModel
+            mockProfileModel,
+            true
           );
 
           const response = await limitedProfileHandler(
@@ -170,7 +173,8 @@ describe("GetLimitedProfileByPOSTHandler", () => {
             )
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
-            mockProfileModel
+            mockProfileModel,
+            true
           );
 
           const response = await limitedProfileHandler(
@@ -213,7 +217,8 @@ describe("GetLimitedProfileByPOSTHandler", () => {
             )
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
-            mockProfileModel
+            mockProfileModel,
+            true
           );
 
           const response = await limitedProfileHandler(
@@ -258,7 +263,8 @@ describe("GetLimitedProfileByPOSTHandler", () => {
             )
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
-            mockProfileModel
+            mockProfileModel,
+            true
           );
 
           const response = await limitedProfileHandler(
@@ -307,7 +313,8 @@ describe("GetLimitedProfileByPOSTHandler", () => {
             )
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
-            mockProfileModel
+            mockProfileModel,
+            true
           );
 
           const response = await limitedProfileHandler(

--- a/GetLimitedProfileByPOST/__tests__/handler.test.ts
+++ b/GetLimitedProfileByPOST/__tests__/handler.test.ts
@@ -56,7 +56,8 @@ describe("GetLimitedProfileByPOSTHandler", () => {
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
             mockProfileModel,
-            true
+            true,
+            []
           );
 
           const response = await limitedProfileHandler(
@@ -92,7 +93,8 @@ describe("GetLimitedProfileByPOSTHandler", () => {
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
             mockProfileModel,
-            true
+            true,
+            []
           );
 
           const response = await limitedProfileHandler(
@@ -135,7 +137,8 @@ describe("GetLimitedProfileByPOSTHandler", () => {
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
             mockProfileModel,
-            true
+            true,
+            []
           );
 
           const response = await limitedProfileHandler(
@@ -174,7 +177,8 @@ describe("GetLimitedProfileByPOSTHandler", () => {
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
             mockProfileModel,
-            true
+            true,
+            []
           );
 
           const response = await limitedProfileHandler(
@@ -218,7 +222,8 @@ describe("GetLimitedProfileByPOSTHandler", () => {
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
             mockProfileModel,
-            true
+            true,
+            []
           );
 
           const response = await limitedProfileHandler(
@@ -264,7 +269,8 @@ describe("GetLimitedProfileByPOSTHandler", () => {
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
             mockProfileModel,
-            true
+            true,
+            []
           );
 
           const response = await limitedProfileHandler(
@@ -314,7 +320,8 @@ describe("GetLimitedProfileByPOSTHandler", () => {
           } as unknown) as ProfileModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
             mockProfileModel,
-            true
+            true,
+            []
           );
 
           const response = await limitedProfileHandler(

--- a/GetLimitedProfileByPOST/__tests__/handler.test.ts
+++ b/GetLimitedProfileByPOST/__tests__/handler.test.ts
@@ -255,6 +255,59 @@ describe("GetLimitedProfileByPOSTHandler", () => {
     );
   });
 
+  it("should respond with ResponseSuccessJson if a withelisted Service hasn't quality fields when the requested profile is found in the db", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        clientIpArb,
+        fiscalCodeArb,
+        retrievedProfileArb,
+        async (clientIp, fiscalCode, retrievedProfile) => {
+          const mockProfileModel = ({
+            findLastVersionByModelId: jest.fn(() =>
+              taskEither.of(some(retrievedProfile))
+            )
+          } as unknown) as ProfileModel;
+          const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
+            mockProfileModel,
+            true,
+            [anIncompleteService.serviceId]
+          );
+
+          const response = await limitedProfileHandler(
+            {
+              ...mockAzureApiAuthorization,
+              groups: new Set([UserGroup.ApiMessageWrite])
+            },
+            clientIp,
+            {
+              ...mockAzureUserAttributes,
+              service: {
+                ...anIncompleteService,
+                authorizedRecipients: new Set([
+                  aFiscalCode === fiscalCode ? anotherFiscalCode : aFiscalCode
+                ])
+              }
+            },
+            { fiscal_code: fiscalCode }
+          );
+
+          expect(
+            mockProfileModel.findLastVersionByModelId
+          ).toHaveBeenCalledTimes(1);
+          expect(mockProfileModel.findLastVersionByModelId).toBeCalledWith([
+            fiscalCode
+          ]);
+          expect(response.kind).toBe("IResponseSuccessJson");
+          if (response.kind === "IResponseSuccessJson") {
+            expect(response.value).toEqual(
+              retrievedProfileToLimitedProfile(retrievedProfile, false)
+            );
+          }
+        }
+      )
+    );
+  });
+
   it("should respond with ResponseSuccessJson when the requested profile is found in the db, the service is sandboxed but can write messages to the profile fiscal code", async () => {
     await fc.assert(
       fc.asyncProperty(

--- a/GetLimitedProfileByPOST/handler.ts
+++ b/GetLimitedProfileByPOST/handler.ts
@@ -1,8 +1,5 @@
 import * as express from "express";
 
-import { isLeft, isRight } from "fp-ts/lib/Either";
-import { isSome } from "fp-ts/lib/Option";
-
 import { LimitedProfile } from "@pagopa/io-functions-commons/dist/generated/definitions/LimitedProfile";
 import { ProfileModel } from "@pagopa/io-functions-commons/dist/src/models/profile";
 import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
@@ -23,10 +20,7 @@ import {
   withRequestMiddlewares,
   wrapRequestHandler
 } from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
-import {
-  IResponseErrorQuery,
-  ResponseErrorQuery
-} from "@pagopa/io-functions-commons/dist/src/utils/response";
+import { IResponseErrorQuery } from "@pagopa/io-functions-commons/dist/src/utils/response";
 import {
   checkSourceIpForHandler,
   clientIPAndCidrTuple as ipTuple
@@ -34,18 +28,13 @@ import {
 import {
   IResponseErrorForbiddenNotAuthorizedForRecipient,
   IResponseErrorNotFound,
-  IResponseSuccessJson,
-  ResponseErrorForbiddenNotAuthorizedForRecipient,
-  ResponseErrorNotFound,
-  ResponseSuccessJson
+  IResponseSuccessJson
 } from "italia-ts-commons/lib/responses";
 
-import { canWriteMessage } from "../CreateMessage/handler";
 import { GetLimitedProfileByPOSTPayload } from "../generated/definitions/GetLimitedProfileByPOSTPayload";
 import {
   GetLimitedProfileByPOSTPayloadMiddleware,
-  isSenderAllowed,
-  retrievedProfileToLimitedProfile
+  getLimitedProfileTask
 } from "../utils/profile";
 
 /**
@@ -73,57 +62,13 @@ export function GetLimitedProfileByPOSTHandler(
   profileModel: ProfileModel
 ): IGetLimitedProfileByPOSTHandler {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  return async (auth, __, userAttributes, payload) => {
-    // Sandboxed accounts will receive 403
-    // if they're not authorized to send a messages to this fiscal code.
-    // This prevents leaking the information, to sandboxed account,
-    // that the fiscal code belongs to a subscribed user
-    if (
-      isLeft(
-        canWriteMessage(
-          auth.groups,
-          userAttributes.service.authorizedRecipients,
-          payload.fiscal_code
-        )
-      )
-    ) {
-      return ResponseErrorForbiddenNotAuthorizedForRecipient;
-    }
-
-    const maybeProfileOrError = await profileModel
-      .findLastVersionByModelId([payload.fiscal_code])
-      .run();
-
-    if (isRight(maybeProfileOrError)) {
-      const maybeProfile = maybeProfileOrError.value;
-
-      // We also return ResponseErrorNotFound in case the profile is found
-      // but the inbox is not enabled (onboarding not completed).
-      if (isSome(maybeProfile) && maybeProfile.value.isInboxEnabled) {
-        const profile = maybeProfile.value;
-
-        return ResponseSuccessJson(
-          retrievedProfileToLimitedProfile(
-            profile,
-            isSenderAllowed(
-              profile.blockedInboxOrChannels,
-              userAttributes.service.serviceId
-            )
-          )
-        );
-      } else {
-        return ResponseErrorNotFound(
-          "Profile not found",
-          "The profile you requested was not found in the system."
-        );
-      }
-    } else {
-      return ResponseErrorQuery(
-        "Error while retrieving the profile",
-        maybeProfileOrError.value
-      );
-    }
-  };
+  return async (auth, __, userAttributes, { fiscal_code }) =>
+    getLimitedProfileTask(
+      auth,
+      userAttributes,
+      fiscal_code,
+      profileModel
+    ).run();
 }
 
 /**

--- a/GetLimitedProfileByPOST/handler.ts
+++ b/GetLimitedProfileByPOST/handler.ts
@@ -59,7 +59,8 @@ type IGetLimitedProfileByPOSTHandler = (
  */
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function GetLimitedProfileByPOSTHandler(
-  profileModel: ProfileModel
+  profileModel: ProfileModel,
+  disableIncompleteServices: boolean
 ): IGetLimitedProfileByPOSTHandler {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   return async (auth, __, userAttributes, { fiscal_code }) =>
@@ -67,7 +68,8 @@ export function GetLimitedProfileByPOSTHandler(
       auth,
       userAttributes,
       fiscal_code,
-      profileModel
+      profileModel,
+      disableIncompleteServices
     ).run();
 }
 
@@ -77,9 +79,13 @@ export function GetLimitedProfileByPOSTHandler(
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function GetLimitedProfileByPOST(
   serviceModel: ServiceModel,
-  profileModel: ProfileModel
+  profileModel: ProfileModel,
+  disableIncompleteServices: boolean
 ): express.RequestHandler {
-  const handler = GetLimitedProfileByPOSTHandler(profileModel);
+  const handler = GetLimitedProfileByPOSTHandler(
+    profileModel,
+    disableIncompleteServices
+  );
 
   const middlewaresWrap = withRequestMiddlewares(
     AzureApiAuthMiddleware(new Set([UserGroup.ApiLimitedProfileRead])),

--- a/GetLimitedProfileByPOST/handler.ts
+++ b/GetLimitedProfileByPOST/handler.ts
@@ -31,6 +31,7 @@ import {
   IResponseSuccessJson
 } from "italia-ts-commons/lib/responses";
 
+import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
 import { GetLimitedProfileByPOSTPayload } from "../generated/definitions/GetLimitedProfileByPOSTPayload";
 import {
   GetLimitedProfileByPOSTPayloadMiddleware,
@@ -60,7 +61,8 @@ type IGetLimitedProfileByPOSTHandler = (
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function GetLimitedProfileByPOSTHandler(
   profileModel: ProfileModel,
-  disableIncompleteServices: boolean
+  disableIncompleteServices: boolean,
+  incompleteServiceWhitelist: ReadonlyArray<ServiceId>
 ): IGetLimitedProfileByPOSTHandler {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   return async (auth, __, userAttributes, { fiscal_code }) =>
@@ -69,7 +71,8 @@ export function GetLimitedProfileByPOSTHandler(
       userAttributes,
       fiscal_code,
       profileModel,
-      disableIncompleteServices
+      disableIncompleteServices,
+      incompleteServiceWhitelist
     ).run();
 }
 
@@ -80,11 +83,13 @@ export function GetLimitedProfileByPOSTHandler(
 export function GetLimitedProfileByPOST(
   serviceModel: ServiceModel,
   profileModel: ProfileModel,
-  disableIncompleteServices: boolean
+  disableIncompleteServices: boolean,
+  incompleteServiceWhitelist: ReadonlyArray<ServiceId>
 ): express.RequestHandler {
   const handler = GetLimitedProfileByPOSTHandler(
     profileModel,
-    disableIncompleteServices
+    disableIncompleteServices,
+    incompleteServiceWhitelist
   );
 
   const middlewaresWrap = withRequestMiddlewares(

--- a/GetLimitedProfileByPOST/index.ts
+++ b/GetLimitedProfileByPOST/index.ts
@@ -39,7 +39,8 @@ app.post(
   GetLimitedProfileByPOST(
     serviceModel,
     profileModel,
-    config.FF_DISABLE_INCOMPLETE_SERVICES
+    config.FF_DISABLE_INCOMPLETE_SERVICES,
+    config.FF_INCOMPLETE_SERVICE_WHITELIST
   )
 );
 

--- a/GetLimitedProfileByPOST/index.ts
+++ b/GetLimitedProfileByPOST/index.ts
@@ -12,6 +12,7 @@ import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middl
 import cors = require("cors");
 import express = require("express");
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
+import { getConfigOrThrow } from "../utils/config";
 import { cosmosdbInstance } from "../utils/cosmosdb";
 
 import { GetLimitedProfileByPOST } from "./handler";
@@ -24,6 +25,8 @@ const profileModel = new ProfileModel(
   cosmosdbInstance.container(PROFILE_COLLECTION_NAME)
 );
 
+const config = getConfigOrThrow();
+
 // Setup Express
 const app = express();
 secureExpressApp(app);
@@ -33,7 +36,11 @@ app.use(cors());
 
 app.post(
   "/api/v1/profiles",
-  GetLimitedProfileByPOST(serviceModel, profileModel)
+  GetLimitedProfileByPOST(
+    serviceModel,
+    profileModel,
+    config.FF_DISABLE_INCOMPLETE_SERVICES
+  )
 );
 
 const azureFunctionHandler = createAzureFunctionHandler(app);

--- a/GetSubscriptionsFeed/__tests__/handler.test.ts
+++ b/GetSubscriptionsFeed/__tests__/handler.test.ts
@@ -75,7 +75,8 @@ describe("GetSubscriptionsFeedHandler", () => {
     const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
       {} as any,
       "subscriptionFeedByDay",
-      true
+      true,
+      []
     );
     const result = await getSubscriptionsFeedHandler(
       {} as any,
@@ -94,7 +95,8 @@ describe("GetSubscriptionsFeedHandler", () => {
     const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
       tableServiceMock,
       "subscriptionFeedByDay",
-      true
+      true,
+      []
     );
 
     const result = await getSubscriptionsFeedHandler(
@@ -129,7 +131,8 @@ describe("GetSubscriptionsFeedHandler", () => {
     const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
       tableServiceMock,
       "subscriptionFeedByDay",
-      true
+      true,
+      []
     );
 
     const result = await getSubscriptionsFeedHandler(
@@ -171,7 +174,8 @@ describe("GetSubscriptionsFeedHandler", () => {
     const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
       tableServiceMock,
       "subscriptionFeedByDay",
-      true
+      true,
+      []
     );
 
     const result = await getSubscriptionsFeedHandler(
@@ -220,7 +224,8 @@ describe("GetSubscriptionsFeedHandler", () => {
     const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
       tableServiceMock,
       "subscriptionFeedByDay",
-      true
+      true,
+      []
     );
 
     const result = await getSubscriptionsFeedHandler(
@@ -265,7 +270,8 @@ describe("GetSubscriptionsFeedHandler", () => {
     const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
       tableServiceMock,
       "subscriptionFeedByDay",
-      true
+      true,
+      []
     );
 
     const result = await getSubscriptionsFeedHandler(
@@ -314,7 +320,8 @@ describe("GetSubscriptionsFeedHandler", () => {
     const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
       tableServiceMock,
       "subscriptionFeedByDay",
-      true
+      true,
+      []
     );
 
     const result = await getSubscriptionsFeedHandler(
@@ -343,7 +350,8 @@ it("should return ResponseErrorForbiddenNotAuthorized if the Service hasn't the 
   const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
     tableServiceMock,
     "subscriptionFeedByDay",
-    true
+    true,
+    []
   );
 
   const result = await getSubscriptionsFeedHandler(

--- a/GetSubscriptionsFeed/__tests__/handler.test.ts
+++ b/GetSubscriptionsFeed/__tests__/handler.test.ts
@@ -74,7 +74,8 @@ describe("GetSubscriptionsFeedHandler", () => {
   it("should respond with Not Found if Date.now() is lower than given subscriptionDate", async () => {
     const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
       {} as any,
-      "subscriptionFeedByDay"
+      "subscriptionFeedByDay",
+      true
     );
     const result = await getSubscriptionsFeedHandler(
       {} as any,
@@ -92,7 +93,8 @@ describe("GetSubscriptionsFeedHandler", () => {
 
     const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
       tableServiceMock,
-      "subscriptionFeedByDay"
+      "subscriptionFeedByDay",
+      true
     );
 
     const result = await getSubscriptionsFeedHandler(
@@ -126,7 +128,8 @@ describe("GetSubscriptionsFeedHandler", () => {
 
     const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
       tableServiceMock,
-      "subscriptionFeedByDay"
+      "subscriptionFeedByDay",
+      true
     );
 
     const result = await getSubscriptionsFeedHandler(
@@ -167,7 +170,8 @@ describe("GetSubscriptionsFeedHandler", () => {
 
     const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
       tableServiceMock,
-      "subscriptionFeedByDay"
+      "subscriptionFeedByDay",
+      true
     );
 
     const result = await getSubscriptionsFeedHandler(
@@ -215,7 +219,8 @@ describe("GetSubscriptionsFeedHandler", () => {
 
     const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
       tableServiceMock,
-      "subscriptionFeedByDay"
+      "subscriptionFeedByDay",
+      true
     );
 
     const result = await getSubscriptionsFeedHandler(
@@ -259,7 +264,8 @@ describe("GetSubscriptionsFeedHandler", () => {
 
     const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
       tableServiceMock,
-      "subscriptionFeedByDay"
+      "subscriptionFeedByDay",
+      true
     );
 
     const result = await getSubscriptionsFeedHandler(
@@ -307,7 +313,8 @@ describe("GetSubscriptionsFeedHandler", () => {
 
     const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
       tableServiceMock,
-      "subscriptionFeedByDay"
+      "subscriptionFeedByDay",
+      true
     );
 
     const result = await getSubscriptionsFeedHandler(
@@ -335,7 +342,8 @@ it("should return ResponseErrorForbiddenNotAuthorized if the Service hasn't the 
 
   const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
     tableServiceMock,
-    "subscriptionFeedByDay"
+    "subscriptionFeedByDay",
+    true
   );
 
   const result = await getSubscriptionsFeedHandler(

--- a/GetSubscriptionsFeed/__tests__/handler.test.ts
+++ b/GetSubscriptionsFeed/__tests__/handler.test.ts
@@ -7,23 +7,21 @@ import { TableService } from "azure-storage";
 import * as dateFmt from "date-fns";
 import * as endOfTomorrow from "date-fns/end_of_tomorrow";
 import * as startOfYesterday from "date-fns/start_of_yesterday";
-import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
 import { FiscalCodeHash } from "../../generated/definitions/FiscalCodeHash";
 import { GetSubscriptionsFeedHandler } from "../handler";
+
+import { anIncompleteService, aValidService } from "../../__mocks__/mocks";
 
 const tomorrow = endOfTomorrow();
 
 const yesterday = startOfYesterday();
-const aServiceId = "MyServiceId" as ServiceId;
 
 const yesterdayUTC = dateFmt.format(yesterday, "YYYY-MM-DD");
 
 const userAttrs = {
   email: "example@mail.com",
   kind: "IAzureUserAttributes",
-  service: {
-    serviceId: aServiceId
-  }
+  service: aValidService
 };
 
 const anHashedFiscalCode = "77408089123C62362C2D70E4C262BB45E268A3D477335D9C4A383521FA772AAE" as FiscalCodeHash;
@@ -61,7 +59,7 @@ const queryEntitiesServiceSubscriptionMock = (
           entries.length > 0
             ? entries.map(e => ({
                 RowKey: {
-                  _: `S-${yesterdayUTC}-${aServiceId}-${subscriptionSuffix}-${e}`
+                  _: `S-${yesterdayUTC}-${aValidService.serviceId}-${subscriptionSuffix}-${e}`
                 }
               }))
             : []
@@ -327,4 +325,28 @@ describe("GetSubscriptionsFeedHandler", () => {
       });
     }
   });
+});
+
+it("should return ResponseErrorForbiddenNotAuthorized if the Service hasn't the required quality fields", async () => {
+  const queryEntities = jest.fn();
+  const tableServiceMock = ({
+    queryEntities
+  } as any) as TableService;
+
+  const getSubscriptionsFeedHandler = GetSubscriptionsFeedHandler(
+    tableServiceMock,
+    "subscriptionFeedByDay"
+  );
+
+  const result = await getSubscriptionsFeedHandler(
+    {} as any,
+    {} as any,
+    {
+      ...userAttrs,
+      service: anIncompleteService
+    } as any,
+    yesterdayUTC
+  );
+  expect(result.kind).toBe("IResponseErrorForbiddenNotAuthorized");
+  expect(queryEntities).not.toBeCalled();
 });

--- a/GetSubscriptionsFeed/handler.ts
+++ b/GetSubscriptionsFeed/handler.ts
@@ -82,7 +82,8 @@ type IGetSubscriptionsFeedHandler = (
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function GetSubscriptionsFeedHandler(
   tableService: TableService,
-  subscriptionsFeedTable: string
+  subscriptionsFeedTable: string,
+  disableIncompleteServices: boolean
 ): IGetSubscriptionsFeedHandler {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   return async (_, __, userAttributes, subscriptionsDateUTC) => {
@@ -102,7 +103,7 @@ export function GetSubscriptionsFeedHandler(
     }
 
     // Verify if the Service has the required quality to read the SubscriptionFeed
-    if (!ValidService.is(userAttributes.service)) {
+    if (disableIncompleteServices && !ValidService.is(userAttributes.service)) {
       return ResponseErrorForbiddenNotAuthorized;
     }
 
@@ -212,11 +213,13 @@ const ShortDateString = t.refinement(
 export function GetSubscriptionsFeed(
   serviceModel: ServiceModel,
   tableService: TableService,
-  subscriptionsFeedTable: string
+  subscriptionsFeedTable: string,
+  disableIncompleteServices: boolean
 ): express.RequestHandler {
   const handler = GetSubscriptionsFeedHandler(
     tableService,
-    subscriptionsFeedTable
+    subscriptionsFeedTable,
+    disableIncompleteServices
   );
   const middlewaresWrap = withRequestMiddlewares(
     AzureApiAuthMiddleware(new Set([UserGroup.ApiSubscriptionsFeedRead])),

--- a/GetSubscriptionsFeed/handler.ts
+++ b/GetSubscriptionsFeed/handler.ts
@@ -30,6 +30,7 @@ import {
   IResponseErrorNotFound,
   IResponseErrorValidation,
   IResponseSuccessJson,
+  ResponseErrorForbiddenNotAuthorized,
   ResponseErrorNotFound,
   ResponseSuccessJson
 } from "italia-ts-commons/lib/responses";
@@ -40,7 +41,10 @@ import {
   clientIPAndCidrTuple as ipTuple
 } from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 
-import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
+import {
+  ServiceModel,
+  ValidService
+} from "@pagopa/io-functions-commons/dist/src/models/service";
 
 import { TableService } from "azure-storage";
 
@@ -95,6 +99,11 @@ export function GetSubscriptionsFeedHandler(
           availableSince
         ).toUTCString()}`
       );
+    }
+
+    // Verify if the Service has the required quality to read the SubscriptionFeed
+    if (!ValidService.is(userAttributes.service)) {
+      return ResponseErrorForbiddenNotAuthorized;
     }
 
     const { serviceId } = userAttributes.service;

--- a/GetSubscriptionsFeed/index.ts
+++ b/GetSubscriptionsFeed/index.ts
@@ -36,7 +36,8 @@ app.get(
   GetSubscriptionsFeed(
     serviceModel,
     tableService,
-    config.SUBSCRIPTIONS_FEED_TABLE
+    config.SUBSCRIPTIONS_FEED_TABLE,
+    config.FF_DISABLE_INCOMPLETE_SERVICES
   )
 );
 

--- a/GetSubscriptionsFeed/index.ts
+++ b/GetSubscriptionsFeed/index.ts
@@ -37,7 +37,8 @@ app.get(
     serviceModel,
     tableService,
     config.SUBSCRIPTIONS_FEED_TABLE,
-    config.FF_DISABLE_INCOMPLETE_SERVICES
+    config.FF_DISABLE_INCOMPLETE_SERVICES,
+    config.FF_INCOMPLETE_SERVICE_WHITELIST
   )
 );
 

--- a/__mocks__/durable-functions.ts
+++ b/__mocks__/durable-functions.ts
@@ -1,0 +1,111 @@
+// tslint:disable: no-any
+
+import { Context } from "@azure/functions";
+import * as df from "durable-functions";
+
+export const mockStatusRunning = {
+  runtimeStatus: df.OrchestrationRuntimeStatus.Running
+};
+export const mockStatusCompleted = {
+  runtimeStatus: df.OrchestrationRuntimeStatus.Completed
+};
+
+export const OrchestrationRuntimeStatus = df.OrchestrationRuntimeStatus;
+
+export const mockStartNew = jest.fn((_, __, ___) =>
+  Promise.resolve("instanceId")
+);
+export const mockGetStatus = jest
+  .fn()
+  .mockImplementation(async () => mockStatusCompleted);
+export const mockTerminate = jest.fn(async (_, __) => {
+  return;
+});
+
+export const mockRaiseEvent = jest.fn().mockImplementation(async () => void 0);
+
+export const getClient = jest.fn().mockImplementation(() => ({
+  getStatus: mockGetStatus,
+  raiseEvent: mockRaiseEvent,
+  startNew: mockStartNew,
+  terminate: mockTerminate
+}));
+
+export const RetryOptions = jest.fn(() => ({}));
+
+export const context = ({
+  bindings: {},
+  log: {
+    // tslint:disable-next-line: no-console
+    error: jest.fn().mockImplementation(console.log),
+    // tslint:disable-next-line: no-console
+    info: jest.fn().mockImplementation(console.log),
+    // tslint:disable-next-line: no-console
+    verbose: jest.fn().mockImplementation(console.log),
+    // tslint:disable-next-line: no-console
+    warn: jest.fn().mockImplementation(console.log)
+  }
+} as any) as Context;
+
+//
+// Orchestrator context
+//
+
+export const mockOrchestratorGetInput = jest.fn();
+export const mockOrchestratorCallActivity = jest
+  .fn()
+  .mockImplementation((name: string, input?: unknown) => ({
+    input,
+    name
+  }));
+export const mockOrchestratorCallActivityWithRetry = jest
+  .fn()
+  .mockImplementation(
+    (name: string, retryOptions: df.RetryOptions, input?: unknown) => ({
+      input,
+      name,
+      retryOptions
+    })
+  );
+export const mockCallSubOrchestrator = jest
+  .fn()
+  .mockImplementation((name: string, input?: unknown) => ({
+    input,
+    name
+  }));
+export const mockOrchestratorSetCustomStatus = jest.fn();
+export const mockOrchestratorCancelTimer = jest.fn();
+export const mockOrchestratorCreateTimer = () => ({
+  cancel: mockOrchestratorCancelTimer
+});
+export const mockWaitForExternalEvent = jest
+  .fn()
+  .mockReturnValue("mockWaitForExternalEvent");
+
+export const mockOrchestratorTaskAny = jest
+  .fn()
+  // mock implementation: return the first task
+  .mockImplementation(([_]) => _);
+
+export const mockOrchestratorContext = {
+  ...context,
+  df: {
+    Task: {
+      all: jest.fn(),
+      any: mockOrchestratorTaskAny
+    },
+    callActivity: mockOrchestratorCallActivity,
+    callActivityWithRetry: mockOrchestratorCallActivityWithRetry,
+    callSubOrchestrator: mockCallSubOrchestrator,
+    createTimer: mockOrchestratorCreateTimer,
+    currentUtcDateTime: new Date(),
+    getClient,
+    getInput: mockOrchestratorGetInput,
+    setCustomStatus: mockOrchestratorSetCustomStatus,
+    waitForExternalEvent: mockWaitForExternalEvent
+  }
+};
+
+export const orchestrator = jest
+  .fn()
+  .mockImplementation(fn => () => fn(mockOrchestratorContext));

--- a/__mocks__/mocks.ts
+++ b/__mocks__/mocks.ts
@@ -1,0 +1,59 @@
+import { ServiceScopeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceScope";
+import {
+  Service,
+  ValidService
+} from "@pagopa/io-functions-commons/dist/src/models/service";
+import {
+  NonNegativeInteger,
+  WithinRangeInteger
+} from "@pagopa/ts-commons/lib/numbers";
+import {
+  FiscalCode,
+  NonEmptyString,
+  OrganizationFiscalCode
+} from "@pagopa/ts-commons/lib/strings";
+import { CIDR } from "../generated/definitions/CIDR";
+
+export const aFiscalCode = "AAABBB01C02D345D" as FiscalCode;
+export const anotherFiscalCode = "AAABBB01C02D345W" as FiscalCode;
+
+export const aValidService: ValidService = {
+  serviceId: "01234567890" as NonEmptyString,
+  authorizedRecipients: new Set([aFiscalCode, anotherFiscalCode]),
+  authorizedCIDRs: new Set((["0.0.0.0"] as unknown) as CIDR[]),
+  departmentName: "department" as NonEmptyString,
+  isVisible: true,
+  maxAllowedPaymentAmount: (0 as unknown) as number &
+    WithinRangeInteger<0, 9999999999>,
+  organizationFiscalCode: "01234567890" as OrganizationFiscalCode,
+  organizationName: "Organization" as NonEmptyString,
+  requireSecureChannels: true,
+  serviceName: "Service" as NonEmptyString,
+  serviceMetadata: {
+    description: "Service Description" as NonEmptyString,
+    privacyUrl: "https://example.com/privacy.html" as NonEmptyString,
+    supportUrl: "https://example.com/support.html" as NonEmptyString,
+    scope: ServiceScopeEnum.NATIONAL
+  }
+};
+
+export const anIncompleteService: Service & {
+  readonly version: NonNegativeInteger;
+} = {
+  serviceId: "01234567890" as NonEmptyString,
+  authorizedRecipients: new Set([aFiscalCode, anotherFiscalCode]),
+  authorizedCIDRs: new Set((["0.0.0.0"] as unknown) as CIDR[]),
+  departmentName: "department" as NonEmptyString,
+  isVisible: true,
+  maxAllowedPaymentAmount: (0 as unknown) as number &
+    WithinRangeInteger<0, 9999999999>,
+  organizationFiscalCode: "01234567890" as OrganizationFiscalCode,
+  organizationName: "Organization" as NonEmptyString,
+  requireSecureChannels: true,
+  serviceName: "Service" as NonEmptyString,
+  serviceMetadata: {
+    description: "Service Description" as NonEmptyString,
+    scope: ServiceScopeEnum.NATIONAL
+  },
+  version: 1 as NonNegativeInteger
+};

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@azure/cosmos": "^3.7.2",
     "@pagopa/io-functions-commons": "^20.3.4",
-    "@pagopa/ts-commons": "^9.1.0",
+    "@pagopa/ts-commons": "^9.4.0",
     "applicationinsights": "^1.7.4",
     "azure-storage": "^2.10.3",
     "cors": "^2.8.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "resolveJsonModule": true
   }, "exclude": [
     "Dangerfile.ts",
-    "**/__tests__"
+    "**/__tests__",
+    "__mocks__/**",
   ]
 }

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -7,6 +7,7 @@
 
 import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
 import { MailerConfig } from "@pagopa/io-functions-commons/dist/src/mailer";
+import { fromNullable } from "fp-ts/lib/Option";
 import * as t from "io-ts";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
@@ -40,6 +41,9 @@ export const IConfig = t.intersection([
 
     WEBHOOK_CHANNEL_URL: NonEmptyString,
 
+    // eslint-disable-next-line sort-keys
+    FF_DISABLE_INCOMPLETE_SERVICES: t.boolean,
+
     isProduction: t.boolean
   }),
   MailerConfig
@@ -48,6 +52,11 @@ export const IConfig = t.intersection([
 // No need to re-evaluate this object for each call
 const errorOrConfig: t.Validation<IConfig> = IConfig.decode({
   ...process.env,
+  FF_DISABLE_INCOMPLETE_SERVICES: fromNullable(
+    process.env.FF_DISABLE_INCOMPLETE_SERVICES
+  )
+    .map(_ => _.toLowerCase() === "true")
+    .getOrElse(false),
   isProduction: process.env.NODE_ENV === "production"
 });
 

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -43,6 +43,7 @@ export const IConfig = t.intersection([
 
     // eslint-disable-next-line sort-keys
     FF_DISABLE_INCOMPLETE_SERVICES: t.boolean,
+    FF_INCOMPLETE_SERVICE_WHITELIST: CommaSeparatedListOf(ServiceId),
 
     isProduction: t.boolean
   }),

--- a/utils/profile.ts
+++ b/utils/profile.ts
@@ -122,9 +122,10 @@ export const getLimitedProfileTask = (
         !userAttributes.service.authorizedRecipients.has(fiscalCode)
       ) {
         return fromEither(
-          ValidService.decode(userAttributes.service)
-            .map(_1 => true)
-            .mapLeft(_1 => ResponseErrorForbiddenNotAuthorizedForRecipient)
+          ValidService.decode(userAttributes.service).bimap(
+            _1 => ResponseErrorForbiddenNotAuthorizedForRecipient,
+            _1 => true
+          )
         );
       }
       return fromEither(right(true));

--- a/utils/profile.ts
+++ b/utils/profile.ts
@@ -89,7 +89,9 @@ export const getLimitedProfileTask = (
   userAttributes: IAzureUserAttributes,
   fiscalCode: FiscalCode,
   profileModel: ProfileModel,
-  disableIncompleteServices: boolean
+  disableIncompleteServices: boolean,
+  incompleteServiceWhitelist: ReadonlyArray<ServiceId>
+  // eslint-disable-next-line max-params
 ): Task<IGetLimitedProfileResponses> =>
   taskEither
     .of<
@@ -114,6 +116,9 @@ export const getLimitedProfileTask = (
     .chain(_ => {
       if (
         disableIncompleteServices &&
+        !incompleteServiceWhitelist.includes(
+          userAttributes.service.serviceId
+        ) &&
         !userAttributes.service.authorizedRecipients.has(fiscalCode)
       ) {
         return fromEither(

--- a/utils/profile.ts
+++ b/utils/profile.ts
@@ -1,9 +1,34 @@
 import { BlockedInboxOrChannelEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
+import { FiscalCode } from "@pagopa/io-functions-commons/dist/generated/definitions/FiscalCode";
 import { LimitedProfile } from "@pagopa/io-functions-commons/dist/generated/definitions/LimitedProfile";
 import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
-import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/profile";
+import {
+  ProfileModel,
+  RetrievedProfile
+} from "@pagopa/io-functions-commons/dist/src/models/profile";
+import { ValidService } from "@pagopa/io-functions-commons/dist/src/models/service";
+import { IAzureApiAuthorization } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+import { IAzureUserAttributes } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
 import { IRequestMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
-import { ResponseErrorFromValidationErrors } from "italia-ts-commons/lib/responses";
+import {
+  IResponseErrorQuery,
+  ResponseErrorQuery
+} from "@pagopa/io-functions-commons/dist/src/utils/response";
+import { Some, isSome } from "fp-ts/lib/Option";
+import { fromEither, fromPredicate, taskEither } from "fp-ts/lib/TaskEither";
+import { right } from "fp-ts/lib/Either";
+import { identity } from "io-ts";
+import {
+  IResponseErrorForbiddenNotAuthorizedForRecipient,
+  IResponseErrorNotFound,
+  IResponseSuccessJson,
+  ResponseErrorForbiddenNotAuthorizedForRecipient,
+  ResponseErrorFromValidationErrors,
+  ResponseErrorNotFound,
+  ResponseSuccessJson
+} from "italia-ts-commons/lib/responses";
+import { Task } from "fp-ts/lib/Task";
+import { canWriteMessage } from "../CreateMessage/handler";
 import { GetLimitedProfileByPOSTPayload } from "../generated/definitions/GetLimitedProfileByPOSTPayload";
 
 /**
@@ -52,3 +77,76 @@ export const GetLimitedProfileByPOSTPayloadMiddleware: IRequestMiddleware<
       ResponseErrorFromValidationErrors(GetLimitedProfileByPOSTPayload)
     )
   );
+
+export type IGetLimitedProfileResponses =
+  | IResponseSuccessJson<LimitedProfile>
+  | IResponseErrorNotFound
+  | IResponseErrorQuery
+  | IResponseErrorForbiddenNotAuthorizedForRecipient;
+
+export const getLimitedProfileTask = (
+  apiAuthorization: IAzureApiAuthorization,
+  userAttributes: IAzureUserAttributes,
+  fiscalCode: FiscalCode,
+  profileModel: ProfileModel
+): Task<IGetLimitedProfileResponses> =>
+  taskEither
+    .of<
+      | IResponseErrorForbiddenNotAuthorizedForRecipient
+      | IResponseErrorNotFound
+      | IResponseErrorQuery,
+      void
+    >(void 0)
+    .chainSecond(
+      // Sandboxed accounts will receive 403
+      // if they're not authorized to send a messages to this fiscal code.
+      // This prevents leaking the information, to sandboxed account,
+      // that the fiscal code belongs to a subscribed user
+      fromEither(
+        canWriteMessage(
+          apiAuthorization.groups,
+          userAttributes.service.authorizedRecipients,
+          fiscalCode
+        )
+      ).mapLeft(_ => ResponseErrorForbiddenNotAuthorizedForRecipient)
+    ) // Verify if the Service has the required quality to sent message
+    .chain(_ => {
+      if (!userAttributes.service.authorizedRecipients.has(fiscalCode)) {
+        return fromEither(
+          ValidService.decode(userAttributes.service)
+            .map(_1 => true)
+            .mapLeft(_1 => ResponseErrorForbiddenNotAuthorizedForRecipient)
+        );
+      }
+      return fromEither(right(true));
+    })
+    .chain(_ =>
+      profileModel
+        .findLastVersionByModelId([fiscalCode])
+        .mapLeft(error =>
+          ResponseErrorQuery("Error while retrieving the profile", error)
+        )
+    )
+    .chain(
+      fromPredicate<IResponseErrorNotFound, Some<RetrievedProfile>>(
+        maybeProfile =>
+          isSome(maybeProfile) && maybeProfile.value.isInboxEnabled,
+        _ =>
+          ResponseErrorNotFound(
+            "Profile not found",
+            "The profile you requested was not found in the system."
+          )
+      )
+    )
+    .map(_ => _.value)
+    .fold<IGetLimitedProfileResponses>(identity, service =>
+      ResponseSuccessJson(
+        retrievedProfileToLimitedProfile(
+          service,
+          isSenderAllowed(
+            service.blockedInboxOrChannels,
+            userAttributes.service.serviceId
+          )
+        )
+      )
+    );

--- a/utils/profile.ts
+++ b/utils/profile.ts
@@ -88,7 +88,8 @@ export const getLimitedProfileTask = (
   apiAuthorization: IAzureApiAuthorization,
   userAttributes: IAzureUserAttributes,
   fiscalCode: FiscalCode,
-  profileModel: ProfileModel
+  profileModel: ProfileModel,
+  disableIncompleteServices: boolean
 ): Task<IGetLimitedProfileResponses> =>
   taskEither
     .of<
@@ -111,7 +112,10 @@ export const getLimitedProfileTask = (
       ).mapLeft(_ => ResponseErrorForbiddenNotAuthorizedForRecipient)
     ) // Verify if the Service has the required quality to sent message
     .chain(_ => {
-      if (!userAttributes.service.authorizedRecipients.has(fiscalCode)) {
+      if (
+        disableIncompleteServices &&
+        !userAttributes.service.authorizedRecipients.has(fiscalCode)
+      ) {
         return fromEither(
           ValidService.decode(userAttributes.service)
             .map(_1 => true)

--- a/yarn.lock
+++ b/yarn.lock
@@ -657,20 +657,6 @@
     write-yaml-file "^4.1.3"
     yargs "^11.1.0"
 
-"@pagopa/ts-commons@^9.1.0":
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/@pagopa/ts-commons/-/ts-commons-9.1.0.tgz#bbb5f41ffa7039e355123cc40411529b55cc1e34"
-  integrity sha512-wRXk/qm1ReYsg9QHC0cYZraZpJw6AB2RYlU1WrcDFXUnbxEqQ2immP1knyaMkbqhm/uD4EXzX6/vKNztUHN+lg==
-  dependencies:
-    abort-controller "^3.0.0"
-    agentkeepalive "^4.1.2"
-    applicationinsights "^1.7.4"
-    fp-ts "1.17.4"
-    io-ts "1.8.5"
-    json-set-map "^1.0.2"
-    node-fetch "^2.6.0"
-    validator "^10.1.0"
-
 "@pagopa/ts-commons@^9.2.0", "@pagopa/ts-commons@^9.4.0":
   version "9.4.0"
   resolved "https://registry.yarnpkg.com/@pagopa/ts-commons/-/ts-commons-9.4.0.tgz#680ba8a43db4c0397e6c4e8f9cfd3d758cc0b30c"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
If the feature flag `FF_DISABLE_INCOMPLETE_SERVICES` is `true` only services matching that `ValidService` type can use:
- CreateMessage
- GetLimitedProfile
- GetLimitedProfileByPOST
- GetSubscriptionFeed
Some Services added into `FF_INCOMPLETE_SERVICE_WHITELIST` can bypass `ValidService` check.
#### Motivation and Context
A Services that haven't the required metadata information can't be enabled to use some API. We need to specify through the feature flag when this filtering is enabled and a whitelist of services that don't need this check.

#### How Has This Been Tested?
unit test
test with `io-mock`

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
