### PR TITLE
[#IP-210] Add 403 to API specs where missing

### DIFF
--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -157,6 +157,8 @@ paths:
           examples: {}
         '401':
           description: Unauthorized
+        '403':
+          description: Forbidden.
         '429':
           description: Too many requests
         '500':
@@ -224,6 +226,8 @@ paths:
           examples: {}
         '401':
           description: Unauthorized
+        '403':
+          description: Forbidden.
         '429':
           description: Too many requests
         '500':
@@ -277,6 +281,8 @@ paths:
                 email: QUEUED
         '401':
           description: Unauthorized
+        '403':
+          description: Forbidden.
         '404':
           description: No message found for the provided ID.
           schema:
@@ -305,6 +311,8 @@ paths:
               version: 1
         '401':
           description: Unauthorized
+        '403':
+          description: Forbidden.
         '404':
           description: No user found for the provided fiscal code.
           schema:
@@ -335,6 +343,8 @@ paths:
               version: 1
         '401':
           description: Unauthorized
+        '403':
+          description: Forbidden.
         '404':
           description: No user found for the provided fiscal code.
           schema:
@@ -397,6 +407,8 @@ paths:
               unsubscriptions: []
         '401':
           description: Unauthorized
+        '403':
+          description: Forbidden.
         '404':
           description: Subscriptions feed not available yet.
           schema:
@@ -434,6 +446,8 @@ paths:
             $ref: '#/definitions/ProblemJson'
         '401':
           description: Unauthorized.
+        '403':
+          description: Forbidden.
         '429':
           description: Too many requests.
         '500':

--- a/openapi/index.yaml.template
+++ b/openapi/index.yaml.template
@@ -149,6 +149,8 @@ paths:
           examples: {}
         "401":
           description: Unauthorized
+        '403':
+          description: Forbidden.
         "429":
           description: Too many requests
         "500":
@@ -207,6 +209,8 @@ paths:
           examples: {}
         "401":
           description: Unauthorized
+        '403':
+          description: Forbidden.
         "429":
           description: Too many requests
         "500":
@@ -251,6 +255,8 @@ paths:
                 email: QUEUED
         "401":
           description: Unauthorized
+        '403':
+          description: Forbidden.
         "404":
           description: No message found for the provided ID.
           schema:
@@ -276,6 +282,8 @@ paths:
               version: 1
         "401":
           description: Unauthorized
+        '403':
+          description: Forbidden.
         "404":
           description: No user found for the provided fiscal code.
           schema:
@@ -306,6 +314,8 @@ paths:
               version: 1
         "401":
           description: Unauthorized
+        '403':
+          description: Forbidden.
         "404":
           description: No user found for the provided fiscal code.
           schema:
@@ -352,6 +362,8 @@ paths:
               unsubscriptions: []
         "401":
           description: Unauthorized
+        '403':
+          description: Forbidden.
         "404":
           description: Subscriptions feed not available yet.
           schema:
@@ -388,6 +400,8 @@ paths:
             $ref: "#/definitions/ProblemJson"
         "401":
           description: Unauthorized.
+        '403':
+          description: Forbidden.
         "429":
           description: Too many requests.
         "500":


### PR DESCRIPTION
Several APIs are exposed without explicitly declaring a 403 can happen, although they actually do. Mostly, this status can happen when the DevPortal user doesn't belong to the group allowed for such operaration.

Operations are: 

- `submitMessageforUserWithFiscalCodeInBody`
- `submitMessageforUser`
- `getMessage`
- `getProfileByPOST`
- `getProfile`
- `getSubscriptionsFeedForDate`
- `createService`
- `getUserServices`