### PR TITLE
[#IP-234] Disable message content for WEBHOOK channel

### DIFF
--- a/WebhookNotificationActivity/index.ts
+++ b/WebhookNotificationActivity/index.ts
@@ -12,10 +12,13 @@ import {
   toFetch
 } from "italia-ts-commons/lib/fetch";
 import { Millisecond } from "italia-ts-commons/lib/units";
+import { getConfigOrThrow } from "../utils/config";
 import { cosmosdbInstance } from "../utils/cosmosdb";
 
 import { getNotifyClient } from "./client";
 import { getWebhookNotificationActivityHandler } from "./handler";
+
+const config = getConfigOrThrow();
 
 const notificationModel = new NotificationModel(
   cosmosdbInstance.container(NOTIFICATION_COLLECTION_NAME)
@@ -34,7 +37,8 @@ const notifyApiCall = getNotifyClient(toFetch(fetchWithTimeout));
 
 const activityFunction: AzureFunction = getWebhookNotificationActivityHandler(
   notificationModel,
-  notifyApiCall
+  notifyApiCall,
+  config.FF_DISABLE_WEBHOOK_MESSAGE_CONTENT
 );
 
 export default activityFunction;

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -43,6 +43,7 @@ export const IConfig = t.intersection([
 
     // eslint-disable-next-line sort-keys
     FF_DISABLE_INCOMPLETE_SERVICES: t.boolean,
+    FF_DISABLE_WEBHOOK_MESSAGE_CONTENT: t.boolean,
     FF_INCOMPLETE_SERVICE_WHITELIST: CommaSeparatedListOf(ServiceId),
 
     isProduction: t.boolean
@@ -55,6 +56,11 @@ const errorOrConfig: t.Validation<IConfig> = IConfig.decode({
   ...process.env,
   FF_DISABLE_INCOMPLETE_SERVICES: fromNullable(
     process.env.FF_DISABLE_INCOMPLETE_SERVICES
+  )
+    .map(_ => _.toLowerCase() === "true")
+    .getOrElse(false),
+  FF_DISABLE_WEBHOOK_MESSAGE_CONTENT: fromNullable(
+    process.env.FF_DISABLE_WEBHOOK_MESSAGE_CONTENT
   )
     .map(_ => _.toLowerCase() === "true")
     .getOrElse(false),


### PR DESCRIPTION
#### List of Changes
- Add new feature flag `FF_DISABLE_WEBHOOK_MESSAGE_CONTENT` in configuration (default `false`)
- With `FF_DISABLE_WEBHOOK_MESSAGE_CONTENT` enabled all the webhook message content will be disabled

#### Motivation and Context
We want send push notifications with a generic payload and title. With `FF_DISABLE_WEBHOOK_MESSAGE_CONTENT` enabled we remove content from the webhook message, and `io-backend` provide a generic one.

#### How Has This Been Tested?
unit test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
