### PR TITLE
[#IP-275] Message creation considers new services preferences

### DIFF
--- a/EmailNotificationActivity/__tests__/handler.test.ts
+++ b/EmailNotificationActivity/__tests__/handler.test.ts
@@ -127,6 +127,10 @@ const input: EmailNotificationActivityInput = {
 
 const lMailerTransporterMock = ({} as unknown) as mail.MailerTransporter;
 
+jest.mock("@pagopa/io-functions-commons/dist/src/mailer", () => ({
+  sendMail: jest.fn()
+}));
+
 describe("getEmailNotificationActivityHandler", () => {
   it("should respond with 'SUCCESS' if the mail is sent", async () => {
     jest.spyOn(mail, "sendMail").mockReturnValueOnce(taskEither.of("SUCCESS"));

--- a/EmailNotificationActivity/handler.ts
+++ b/EmailNotificationActivity/handler.ts
@@ -15,7 +15,7 @@ import {
 } from "@pagopa/io-functions-commons/dist/src/models/notification";
 import { NotificationEvent } from "@pagopa/io-functions-commons/dist/src/models/notification_event";
 
-import { sendMail } from "@pagopa/io-functions-commons/dist/src/mailer";
+import { sendMail } from "@pagopa/io-functions-commons/dist/src/mailer/transports";
 import { generateDocumentHtml } from "./utils";
 
 export interface INotificationDefaults {

--- a/GetLimitedProfile/__tests__/handler.test.ts
+++ b/GetLimitedProfile/__tests__/handler.test.ts
@@ -18,7 +18,7 @@ import {
   fiscalCodeArb,
   retrievedProfileArb
 } from "../../utils/__tests__/arbitraries";
-import { retrievedProfileToLimitedProfile } from "../../utils/profile";
+import { retrievedProfileToLimitedProfile } from "../../utils/profile-services";
 import { GetLimitedProfileHandler } from "../handler";
 import {
   aFiscalCode,
@@ -26,6 +26,7 @@ import {
   anotherFiscalCode,
   aValidService
 } from "../../__mocks__/mocks";
+import { ServicesPreferencesModel } from "@pagopa/io-functions-commons/dist/src/models/service_preference";
 
 // eslint-disable-next-line sonar/sonar-max-lines-per-function
 describe("GetLimitedProfileHandler", () => {
@@ -51,10 +52,14 @@ describe("GetLimitedProfileHandler", () => {
           const mockProfileModel = ({
             findLastVersionByModelId: jest.fn(() => fromLeft({}))
           } as unknown) as ProfileModel;
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
             mockProfileModel,
             true,
-            []
+            [],
+            mockServicesPreferencesModel
           );
 
           const response = await limitedProfileHandler(
@@ -88,10 +93,14 @@ describe("GetLimitedProfileHandler", () => {
           const mockProfileModel = ({
             findLastVersionByModelId: jest.fn(() => taskEither.of(none))
           } as unknown) as ProfileModel;
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
             mockProfileModel,
             true,
-            []
+            [],
+            mockServicesPreferencesModel
           );
 
           const response = await limitedProfileHandler(
@@ -132,10 +141,14 @@ describe("GetLimitedProfileHandler", () => {
               taskEither.of(some(retrievedProfileWithInboxDisabled))
             )
           } as unknown) as ProfileModel;
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
             mockProfileModel,
             true,
-            []
+            [],
+            mockServicesPreferencesModel
           );
 
           const response = await limitedProfileHandler(
@@ -172,10 +185,14 @@ describe("GetLimitedProfileHandler", () => {
               taskEither.of(some(retrievedProfile))
             )
           } as unknown) as ProfileModel;
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
             mockProfileModel,
             true,
-            []
+            [],
+            mockServicesPreferencesModel
           );
 
           const response = await limitedProfileHandler(
@@ -219,10 +236,14 @@ describe("GetLimitedProfileHandler", () => {
               taskEither.of(some(retrievedProfile))
             )
           } as unknown) as ProfileModel;
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
             mockProfileModel,
             true,
-            []
+            [],
+            mockServicesPreferencesModel
           );
 
           const response = await limitedProfileHandler(
@@ -254,7 +275,7 @@ describe("GetLimitedProfileHandler", () => {
     );
   });
 
-  it("should respond with ResponseSuccessJson if a withelisted Service hasn't quality fields when the requested profile is found in the db", async () => {
+  it("should respond with ResponseSuccessJson if a withelisted Service hasn't quality fields when the requested profile is found in the db for LEGACY profile", async () => {
     await fc.assert(
       fc.asyncProperty(
         clientIpArb,
@@ -266,10 +287,14 @@ describe("GetLimitedProfileHandler", () => {
               taskEither.of(some(retrievedProfile))
             )
           } as unknown) as ProfileModel;
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
             mockProfileModel,
             true,
-            [anIncompleteService.serviceId]
+            [anIncompleteService.serviceId],
+            mockServicesPreferencesModel
           );
 
           const response = await limitedProfileHandler(
@@ -307,7 +332,7 @@ describe("GetLimitedProfileHandler", () => {
     );
   });
 
-  it("should respond with ResponseSuccessJson when the requested profile is found in the db, the service is sandboxed but can write messages to the profile fiscal code", async () => {
+  it("should respond with ResponseSuccessJson when the requested profile is found in the db, the service is sandboxed but can write messages to the profile fiscal code for LEGACY profile", async () => {
     await fc.assert(
       fc.asyncProperty(
         clientIpArb,
@@ -319,10 +344,14 @@ describe("GetLimitedProfileHandler", () => {
               taskEither.of(some(retrievedProfile))
             )
           } as unknown) as ProfileModel;
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
             mockProfileModel,
             true,
-            []
+            [],
+            mockServicesPreferencesModel
           );
 
           const response = await limitedProfileHandler(
@@ -358,7 +387,7 @@ describe("GetLimitedProfileHandler", () => {
     );
   });
 
-  it("should respond with ResponseSuccessJson when the requested profile is found in the db", async () => {
+  it("should respond with ResponseSuccessJson when the requested profile is found in the db for LEGACY profile", async () => {
     await fc.assert(
       fc.asyncProperty(
         clientIpArb,
@@ -370,10 +399,14 @@ describe("GetLimitedProfileHandler", () => {
               taskEither.of(some(retrievedProfile))
             )
           } as unknown) as ProfileModel;
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
           const limitedProfileHandler = GetLimitedProfileHandler(
             mockProfileModel,
             true,
-            []
+            [],
+            mockServicesPreferencesModel
           );
 
           const response = await limitedProfileHandler(

--- a/GetLimitedProfile/handler.ts
+++ b/GetLimitedProfile/handler.ts
@@ -1,6 +1,7 @@
 import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
 import { ProfileModel } from "@pagopa/io-functions-commons/dist/src/models/profile";
 import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
+import { ServicesPreferencesModel } from "@pagopa/io-functions-commons/dist/src/models/service_preference";
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
@@ -51,7 +52,8 @@ type IGetLimitedProfileHandler = (
 export function GetLimitedProfileHandler(
   profileModel: ProfileModel,
   disableIncompleteServices: boolean,
-  incompleteServiceWhitelist: ReadonlyArray<ServiceId>
+  incompleteServiceWhitelist: ReadonlyArray<ServiceId>,
+  servicesPreferencesModel: ServicesPreferencesModel
 ): IGetLimitedProfileHandler {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   return async (auth, __, userAttributes, fiscalCode) =>
@@ -61,7 +63,8 @@ export function GetLimitedProfileHandler(
       fiscalCode,
       profileModel,
       disableIncompleteServices,
-      incompleteServiceWhitelist
+      incompleteServiceWhitelist,
+      servicesPreferencesModel
     ).run();
 }
 
@@ -73,12 +76,14 @@ export function GetLimitedProfile(
   serviceModel: ServiceModel,
   profileModel: ProfileModel,
   disableIncompleteServices: boolean,
-  incompleteServiceWhitelist: ReadonlyArray<ServiceId>
+  incompleteServiceWhitelist: ReadonlyArray<ServiceId>,
+  servicesPreferencesModel: ServicesPreferencesModel
 ): express.RequestHandler {
   const handler = GetLimitedProfileHandler(
     profileModel,
     disableIncompleteServices,
-    incompleteServiceWhitelist
+    incompleteServiceWhitelist,
+    servicesPreferencesModel
   );
 
   const middlewaresWrap = withRequestMiddlewares(

--- a/GetLimitedProfile/index.ts
+++ b/GetLimitedProfile/index.ts
@@ -7,6 +7,10 @@ import {
   SERVICE_COLLECTION_NAME,
   ServiceModel
 } from "@pagopa/io-functions-commons/dist/src/models/service";
+import {
+  SERVICE_PREFERENCES_COLLECTION_NAME,
+  ServicesPreferencesModel
+} from "@pagopa/io-functions-commons/dist/src/models/service_preference";
 import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
 import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import cors = require("cors");
@@ -34,13 +38,19 @@ const profileModel = new ProfileModel(
   cosmosdbInstance.container(PROFILE_COLLECTION_NAME)
 );
 
+const servicesPreferencesModel = new ServicesPreferencesModel(
+  cosmosdbInstance.container(SERVICE_PREFERENCES_COLLECTION_NAME),
+  SERVICE_PREFERENCES_COLLECTION_NAME
+);
+
 app.get(
   "/api/v1/profiles/:fiscalcode",
   GetLimitedProfile(
     serviceModel,
     profileModel,
     config.FF_DISABLE_INCOMPLETE_SERVICES,
-    config.FF_INCOMPLETE_SERVICE_WHITELIST
+    config.FF_INCOMPLETE_SERVICE_WHITELIST,
+    servicesPreferencesModel
   )
 );
 

--- a/GetLimitedProfileByPOST/__tests__/handler.test.ts
+++ b/GetLimitedProfileByPOST/__tests__/handler.test.ts
@@ -21,7 +21,7 @@ import {
   fiscalCodeArb,
   retrievedProfileArb
 } from "../../utils/__tests__/arbitraries";
-import { retrievedProfileToLimitedProfile } from "../../utils/profile";
+import { retrievedProfileToLimitedProfile } from "../../utils/profile-services";
 import { GetLimitedProfileByPOSTHandler } from "../handler";
 import {
   aFiscalCode,
@@ -29,6 +29,7 @@ import {
   anotherFiscalCode,
   aValidService
 } from "../../__mocks__/mocks";
+import { ServicesPreferencesModel } from "@pagopa/io-functions-commons/dist/src/models/service_preference";
 
 // eslint-disable-next-line sonar/sonar-max-lines-per-function
 describe("GetLimitedProfileByPOSTHandler", () => {
@@ -54,10 +55,14 @@ describe("GetLimitedProfileByPOSTHandler", () => {
           const mockProfileModel = ({
             findLastVersionByModelId: jest.fn(() => fromLeft({}))
           } as unknown) as ProfileModel;
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
             mockProfileModel,
             true,
-            []
+            [],
+            mockServicesPreferencesModel
           );
 
           const response = await limitedProfileHandler(
@@ -91,10 +96,14 @@ describe("GetLimitedProfileByPOSTHandler", () => {
           const mockProfileModel = ({
             findLastVersionByModelId: jest.fn(() => taskEither.of(none))
           } as unknown) as ProfileModel;
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
             mockProfileModel,
             true,
-            []
+            [],
+            mockServicesPreferencesModel
           );
 
           const response = await limitedProfileHandler(
@@ -135,10 +144,14 @@ describe("GetLimitedProfileByPOSTHandler", () => {
               taskEither.of(some(retrievedProfileWithInboxDisabled))
             )
           } as unknown) as ProfileModel;
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
             mockProfileModel,
             true,
-            []
+            [],
+            mockServicesPreferencesModel
           );
 
           const response = await limitedProfileHandler(
@@ -175,10 +188,14 @@ describe("GetLimitedProfileByPOSTHandler", () => {
               taskEither.of(some(retrievedProfile))
             )
           } as unknown) as ProfileModel;
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
             mockProfileModel,
             true,
-            []
+            [],
+            mockServicesPreferencesModel
           );
 
           const response = await limitedProfileHandler(
@@ -220,10 +237,14 @@ describe("GetLimitedProfileByPOSTHandler", () => {
               taskEither.of(some(retrievedProfile))
             )
           } as unknown) as ProfileModel;
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
             mockProfileModel,
             true,
-            []
+            [],
+            mockServicesPreferencesModel
           );
 
           const response = await limitedProfileHandler(
@@ -267,10 +288,14 @@ describe("GetLimitedProfileByPOSTHandler", () => {
               taskEither.of(some(retrievedProfile))
             )
           } as unknown) as ProfileModel;
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
             mockProfileModel,
             true,
-            [anIncompleteService.serviceId]
+            [anIncompleteService.serviceId],
+            mockServicesPreferencesModel
           );
 
           const response = await limitedProfileHandler(
@@ -320,10 +345,14 @@ describe("GetLimitedProfileByPOSTHandler", () => {
               taskEither.of(some(retrievedProfile))
             )
           } as unknown) as ProfileModel;
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
             mockProfileModel,
             true,
-            []
+            [],
+            mockServicesPreferencesModel
           );
 
           const response = await limitedProfileHandler(
@@ -371,10 +400,14 @@ describe("GetLimitedProfileByPOSTHandler", () => {
               taskEither.of(some(retrievedProfile))
             )
           } as unknown) as ProfileModel;
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
           const limitedProfileHandler = GetLimitedProfileByPOSTHandler(
             mockProfileModel,
             true,
-            []
+            [],
+            mockServicesPreferencesModel
           );
 
           const response = await limitedProfileHandler(

--- a/GetLimitedProfileByPOST/__tests__/handler.test.ts
+++ b/GetLimitedProfileByPOST/__tests__/handler.test.ts
@@ -276,7 +276,7 @@ describe("GetLimitedProfileByPOSTHandler", () => {
     );
   });
 
-  it("should respond with ResponseSuccessJson if a withelisted Service hasn't quality fields when the requested profile is found in the db", async () => {
+  it("should respond with ResponseSuccessJson if a withelisted Service hasn't quality fields when the requested profile is found in the db for LEGACY profile", async () => {
     await fc.assert(
       fc.asyncProperty(
         clientIpArb,
@@ -333,7 +333,7 @@ describe("GetLimitedProfileByPOSTHandler", () => {
     );
   });
 
-  it("should respond with ResponseSuccessJson when the requested profile is found in the db, the service is sandboxed but can write messages to the profile fiscal code", async () => {
+  it("should respond with ResponseSuccessJson when the requested profile is found in the db, the service is sandboxed but can write messages to the profile fiscal code for LEGACY profile", async () => {
     await fc.assert(
       fc.asyncProperty(
         clientIpArb,
@@ -388,7 +388,7 @@ describe("GetLimitedProfileByPOSTHandler", () => {
     );
   });
 
-  it("should respond with ResponseSuccessJson when the requested profile is found in the db", async () => {
+  it("should respond with ResponseSuccessJson when the requested profile is found in the db for LEGACY profile", async () => {
     await fc.assert(
       fc.asyncProperty(
         clientIpArb,

--- a/GetLimitedProfileByPOST/handler.ts
+++ b/GetLimitedProfileByPOST/handler.ts
@@ -32,6 +32,7 @@ import {
 } from "italia-ts-commons/lib/responses";
 
 import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
+import { ServicesPreferencesModel } from "@pagopa/io-functions-commons/dist/src/models/service_preference";
 import { GetLimitedProfileByPOSTPayload } from "../generated/definitions/GetLimitedProfileByPOSTPayload";
 import {
   GetLimitedProfileByPOSTPayloadMiddleware,
@@ -62,7 +63,8 @@ type IGetLimitedProfileByPOSTHandler = (
 export function GetLimitedProfileByPOSTHandler(
   profileModel: ProfileModel,
   disableIncompleteServices: boolean,
-  incompleteServiceWhitelist: ReadonlyArray<ServiceId>
+  incompleteServiceWhitelist: ReadonlyArray<ServiceId>,
+  servicesPreferencesModel: ServicesPreferencesModel
 ): IGetLimitedProfileByPOSTHandler {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   return async (auth, __, userAttributes, { fiscal_code }) =>
@@ -72,7 +74,8 @@ export function GetLimitedProfileByPOSTHandler(
       fiscal_code,
       profileModel,
       disableIncompleteServices,
-      incompleteServiceWhitelist
+      incompleteServiceWhitelist,
+      servicesPreferencesModel
     ).run();
 }
 
@@ -84,12 +87,14 @@ export function GetLimitedProfileByPOST(
   serviceModel: ServiceModel,
   profileModel: ProfileModel,
   disableIncompleteServices: boolean,
-  incompleteServiceWhitelist: ReadonlyArray<ServiceId>
+  incompleteServiceWhitelist: ReadonlyArray<ServiceId>,
+  servicesPreferencesModel: ServicesPreferencesModel
 ): express.RequestHandler {
   const handler = GetLimitedProfileByPOSTHandler(
     profileModel,
     disableIncompleteServices,
-    incompleteServiceWhitelist
+    incompleteServiceWhitelist,
+    servicesPreferencesModel
   );
 
   const middlewaresWrap = withRequestMiddlewares(

--- a/GetLimitedProfileByPOST/index.ts
+++ b/GetLimitedProfileByPOST/index.ts
@@ -7,6 +7,10 @@ import {
   SERVICE_COLLECTION_NAME,
   ServiceModel
 } from "@pagopa/io-functions-commons/dist/src/models/service";
+import {
+  ServicesPreferencesModel,
+  SERVICE_PREFERENCES_COLLECTION_NAME
+} from "@pagopa/io-functions-commons/dist/src/models/service_preference";
 import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
 import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import cors = require("cors");
@@ -25,6 +29,11 @@ const profileModel = new ProfileModel(
   cosmosdbInstance.container(PROFILE_COLLECTION_NAME)
 );
 
+const servicesPreferencesModel = new ServicesPreferencesModel(
+  cosmosdbInstance.container(SERVICE_PREFERENCES_COLLECTION_NAME),
+  SERVICE_PREFERENCES_COLLECTION_NAME
+);
+
 const config = getConfigOrThrow();
 
 // Setup Express
@@ -40,7 +49,8 @@ app.post(
     serviceModel,
     profileModel,
     config.FF_DISABLE_INCOMPLETE_SERVICES,
-    config.FF_INCOMPLETE_SERVICE_WHITELIST
+    config.FF_INCOMPLETE_SERVICE_WHITELIST,
+    servicesPreferencesModel
   )
 );
 

--- a/StoreMessageContentActivity/__tests__/handler.test.ts
+++ b/StoreMessageContentActivity/__tests__/handler.test.ts
@@ -45,12 +45,12 @@ const mockContext = {
   }
 } as any;
 
-const findLastVersionByModelIdMock = jest
+const findLastProfileVersionByModelIdMock = jest
   .fn()
   .mockImplementation(() => taskEither.of(some(aRetrievedProfile)));
 
 const profileModelMock = {
-  findLastVersionByModelId: jest.fn(findLastVersionByModelIdMock)
+  findLastVersionByModelId: jest.fn(findLastProfileVersionByModelIdMock)
 };
 
 const aBlobResult = {
@@ -131,7 +131,7 @@ describe("getStoreMessageContentActivityHandler", () => {
   });
 
   it("should respond success with a retrieved profile mantaining its original isEmailEnabled property", async () => {
-    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
       taskEither.of(some(aRetrievedProfileWithAValidTimestamp))
     );
     const storeMessageContentActivityHandler = getStoreMessageContentActivityHandler(
@@ -176,7 +176,7 @@ describe("getStoreMessageContentActivityHandler", () => {
   });
 
   it("should throw an Error if there is an error while fetching profile", async () => {
-    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
       fromLeft("Profile fetch error")
     );
     const storeMessageContentActivityHandler = getStoreMessageContentActivityHandler(
@@ -193,7 +193,7 @@ describe("getStoreMessageContentActivityHandler", () => {
   });
 
   it("should return a failure if no profile was found", async () => {
-    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
       taskEither.of(none)
     );
     const storeMessageContentActivityHandler = getStoreMessageContentActivityHandler(
@@ -216,7 +216,7 @@ describe("getStoreMessageContentActivityHandler", () => {
   });
 
   it("should return a failure if inbox is not enabled", async () => {
-    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
       taskEither.of(some({ ...aRetrievedProfile, isInboxEnabled: false }))
     );
     const storeMessageContentActivityHandler = getStoreMessageContentActivityHandler(
@@ -239,7 +239,7 @@ describe("getStoreMessageContentActivityHandler", () => {
   });
 
   it("should return a failure if message sender is blocked", async () => {
-    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
       taskEither.of(
         some({
           ...aRetrievedProfile,
@@ -306,7 +306,7 @@ describe("getStoreMessageContentActivityHandler", () => {
   });
 
   it("should throw an Error if user's service preference retrieval fails (AUTO SETTINGS)", async () => {
-    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
       taskEither.of(
         some({
           ...aRetrievedProfile,
@@ -335,9 +335,9 @@ describe("getStoreMessageContentActivityHandler", () => {
       storeMessageContentActivityHandler(mockContext, aCreatedMessageEvent)
     ).rejects.toThrow();
 
-    expect(findLastVersionByModelIdMock).toHaveBeenCalled();
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledTimes(1);
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledWith([
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
       aRetrievedProfile.fiscalCode
     ]);
 
@@ -355,7 +355,7 @@ describe("getStoreMessageContentActivityHandler", () => {
   });
 
   it("should throw an Error if user's service preference retrieval fails (MANUAL SETTINGS)", async () => {
-    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
       taskEither.of(
         some({
           ...aRetrievedProfile,
@@ -384,9 +384,9 @@ describe("getStoreMessageContentActivityHandler", () => {
       storeMessageContentActivityHandler(mockContext, aCreatedMessageEvent)
     ).rejects.toThrow();
 
-    expect(findLastVersionByModelIdMock).toHaveBeenCalled();
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledTimes(1);
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledWith([
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
       aRetrievedProfile.fiscalCode
     ]);
 
@@ -403,11 +403,11 @@ describe("getStoreMessageContentActivityHandler", () => {
     ]);
   });
 
-  it("should not throw if user's service preference retrieval fails (LEGACY SETTINGS)", async () => {
+  it("should not throw if user's service preference retrieval fails and return success service is not in blockedInboxOrChannels (LEGACY SETTINGS)", async () => {
     // LEGACY settings should not run any query on service preferences
     // so this should not throw any error because query is not run
 
-    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
       taskEither.of(
         some({
           ...aRetrievedProfile,
@@ -446,16 +446,120 @@ describe("getStoreMessageContentActivityHandler", () => {
     // findServicePreferenceMock is not mocked because it should not be called
     // senderServiceId: "01234567890" is not in blockedInboxOrChannels
     // => SUCCESS
-    expect(findLastVersionByModelIdMock).toHaveBeenCalled();
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledTimes(1);
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledWith([
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
       aRetrievedProfile.fiscalCode
     ]);
     expect(findServicePreferenceMock).not.toHaveBeenCalled();
   });
 
-  it("should return a success if message sender service does not exists in user service preference (AUTO SETTINGS)", async () => {
-    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+  it("should not throw if user's service preference retrieval fails and return success if inbox is not disabled in blockedInboxOrChannels (LEGACY SETTINGS)", async () => {
+    // LEGACY settings should not run any query on service preferences
+    // so this should not throw any error because query is not run
+
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(
+        some({
+          ...aRetrievedProfile,
+          servicePreferencesSettings: legacyProfileServicePreferencesSettings,
+          blockedInboxOrChannels: {
+            "01234567890": [BlockedInboxOrChannelEnum.EMAIL]
+          }
+        })
+      )
+    );
+
+    const storeMessageContentActivityHandler = getStoreMessageContentActivityHandler(
+      profileModelMock as any,
+      messageModelMock as any,
+      {} as any,
+      mockServicesPreferencesModel as any,
+      aPastOptOutEmailSwitchDate
+    );
+
+    const result: StoreMessageContentActivityResult = await storeMessageContentActivityHandler(
+      mockContext,
+      {
+        ...aCreatedMessageEvent,
+        message: {
+          ...aNewMessageWithoutContent,
+          senderServiceId: "01234567890" as ServiceId
+        }
+      }
+    );
+
+    expect(result.kind).toBe("SUCCESS");
+    if (result.kind === "SUCCESS") {
+      expect(result.blockedInboxOrChannels).toEqual([
+        BlockedInboxOrChannelEnum.EMAIL
+      ]);
+    }
+
+    // findServicePreferenceMock is not mocked because it should not be called
+    // senderServiceId: "01234567890" is in blockedInboxOrChannels for EMAIL
+    // => SUCCESS
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
+      aRetrievedProfile.fiscalCode
+    ]);
+    expect(findServicePreferenceMock).not.toHaveBeenCalled();
+  });
+
+  it("should not throw if user's service preference retrieval fails and return failure if inbox is disabled in blockedInboxOrChannels (LEGACY SETTINGS)", async () => {
+    // LEGACY settings should not run any query on service preferences
+    // so this should not throw any error because query is not run
+
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(
+        some({
+          ...aRetrievedProfile,
+          servicePreferencesSettings: legacyProfileServicePreferencesSettings,
+          blockedInboxOrChannels: {
+            "01234567890": [BlockedInboxOrChannelEnum.INBOX]
+          }
+        })
+      )
+    );
+
+    const storeMessageContentActivityHandler = getStoreMessageContentActivityHandler(
+      profileModelMock as any,
+      messageModelMock as any,
+      {} as any,
+      mockServicesPreferencesModel as any,
+      aPastOptOutEmailSwitchDate
+    );
+
+    const result: StoreMessageContentActivityResult = await storeMessageContentActivityHandler(
+      mockContext,
+      {
+        ...aCreatedMessageEvent,
+        message: {
+          ...aNewMessageWithoutContent,
+          senderServiceId: "01234567890" as ServiceId
+        }
+      }
+    );
+
+    expect(result.kind).toBe("FAILURE");
+    if (result.kind === "FAILURE") {
+      expect(result.reason).toEqual("SENDER_BLOCKED");
+    }
+
+    // findServicePreferenceMock is not mocked because it should not be called
+    // senderServiceId: "01234567890" is in blockedInboxOrChannels for INBOX
+    // => FAILURE
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
+      aRetrievedProfile.fiscalCode
+    ]);
+    expect(findServicePreferenceMock).not.toHaveBeenCalled();
+  });
+
+  it("should return a success with empty blockedInboxOrChannels if message sender service does not exists in user service preference (AUTO SETTINGS)", async () => {
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
       taskEither.of(
         some({
           ...aRetrievedProfile,
@@ -493,14 +597,13 @@ describe("getStoreMessageContentActivityHandler", () => {
 
     expect(result.kind).toBe("SUCCESS");
     if (result.kind === "SUCCESS") {
-      expect(result.blockedInboxOrChannels).toEqual([
-        BlockedInboxOrChannelEnum.INBOX
-      ]);
+      // we expect that blockedInboxOrChannels is overridden by AUTO setting
+      expect(result.blockedInboxOrChannels).toEqual([]);
     }
 
-    expect(findLastVersionByModelIdMock).toHaveBeenCalled();
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledTimes(1);
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledWith([
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
       aRetrievedProfile.fiscalCode
     ]);
 
@@ -518,7 +621,7 @@ describe("getStoreMessageContentActivityHandler", () => {
   });
 
   it("should return a success if message sender service exists and is enabled in user service preference (AUTO SETTINGS)", async () => {
-    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
       taskEither.of(
         some({
           ...aRetrievedProfile,
@@ -561,14 +664,85 @@ describe("getStoreMessageContentActivityHandler", () => {
 
     expect(result.kind).toBe("SUCCESS");
     if (result.kind === "SUCCESS") {
+      // we expect that blockedInboxOrChannels is overridden by AUTO setting
+      // with service preferences
+      expect(result.blockedInboxOrChannels).toEqual([]);
+    }
+
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
+      aRetrievedProfile.fiscalCode
+    ]);
+
+    const documentId = makeServicesPreferencesDocumentId(
+      aRetrievedProfile.fiscalCode,
+      "01234567890" as NonEmptyString,
+      autoProfileServicePreferencesSettings.version as NonNegativeInteger
+    );
+    expect(findServicePreferenceMock).toHaveBeenCalled();
+    expect(findServicePreferenceMock).toHaveBeenCalledTimes(1);
+    expect(findServicePreferenceMock).toHaveBeenCalledWith([
+      documentId,
+      aRetrievedProfile.fiscalCode
+    ]);
+  });
+
+  it("should return a success with a blocked EMAIL if sender service exists and has EMAIL disabled in user service preference (AUTO SETTINGS)", async () => {
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(
+        some({
+          ...aRetrievedProfile,
+          servicePreferencesSettings: autoProfileServicePreferencesSettings,
+          blockedInboxOrChannels: {
+            "01234567890": [BlockedInboxOrChannelEnum.INBOX]
+          }
+        })
+      )
+    );
+
+    findServicePreferenceMock.mockImplementationOnce(
+      ([modelId, partitionKey]) =>
+        taskEither.of<CosmosErrors, Option<ServicePreference>>(
+          some({
+            ...anEnabledServicePreference,
+            isEmailEnabled: false, // we disable email for this test
+            version: autoProfileServicePreferencesSettings.version
+          })
+        )
+    );
+
+    const storeMessageContentActivityHandler = getStoreMessageContentActivityHandler(
+      profileModelMock as any,
+      messageModelMock as any,
+      {} as any,
+      mockServicesPreferencesModel as any,
+      aPastOptOutEmailSwitchDate
+    );
+
+    const result: StoreMessageContentActivityResult = await storeMessageContentActivityHandler(
+      mockContext,
+      {
+        ...aCreatedMessageEvent,
+        message: {
+          ...aNewMessageWithoutContent,
+          senderServiceId: "01234567890" as ServiceId
+        }
+      }
+    );
+
+    expect(result.kind).toBe("SUCCESS");
+    if (result.kind === "SUCCESS") {
+      // we expect that blockedInboxOrChannels is overridden by AUTO setting
+      // with service preferences with disabled EMAIL
       expect(result.blockedInboxOrChannels).toEqual([
-        BlockedInboxOrChannelEnum.INBOX
+        BlockedInboxOrChannelEnum.EMAIL
       ]);
     }
 
-    expect(findLastVersionByModelIdMock).toHaveBeenCalled();
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledTimes(1);
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledWith([
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
       aRetrievedProfile.fiscalCode
     ]);
 
@@ -586,7 +760,7 @@ describe("getStoreMessageContentActivityHandler", () => {
   });
 
   it("should return a failure if message sender service exists and is not enabled in user service preference (AUTO SETTINGS)", async () => {
-    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
       taskEither.of(
         some({
           ...aRetrievedProfile,
@@ -632,9 +806,77 @@ describe("getStoreMessageContentActivityHandler", () => {
       expect(result.reason).toEqual("SENDER_BLOCKED");
     }
 
-    expect(findLastVersionByModelIdMock).toHaveBeenCalled();
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledTimes(1);
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledWith([
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
+      aRetrievedProfile.fiscalCode
+    ]);
+
+    const documentId = makeServicesPreferencesDocumentId(
+      aRetrievedProfile.fiscalCode,
+      "01234567890" as NonEmptyString,
+      autoProfileServicePreferencesSettings.version as NonNegativeInteger
+    );
+    expect(findServicePreferenceMock).toHaveBeenCalled();
+    expect(findServicePreferenceMock).toHaveBeenCalledTimes(1);
+    expect(findServicePreferenceMock).toHaveBeenCalledWith([
+      documentId,
+      aRetrievedProfile.fiscalCode
+    ]);
+  });
+
+  it("should return a failure if message sender service exists and has only INBOX disabled in user service preference (AUTO SETTINGS)", async () => {
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(
+        some({
+          ...aRetrievedProfile,
+          servicePreferencesSettings: autoProfileServicePreferencesSettings,
+          blockedInboxOrChannels: {
+            "01234567890": [BlockedInboxOrChannelEnum.INBOX]
+          }
+        })
+      )
+    );
+
+    findServicePreferenceMock.mockImplementationOnce(
+      ([modelId, partitionKey]) =>
+        taskEither.of<CosmosErrors, Option<ServicePreference>>(
+          some({
+            ...aDisabledServicePreference,
+            isEmailEnabled: true,
+            isWebhookEnabled: true,
+            version: autoProfileServicePreferencesSettings.version
+          })
+        )
+    );
+
+    const storeMessageContentActivityHandler = getStoreMessageContentActivityHandler(
+      profileModelMock as any,
+      messageModelMock as any,
+      {} as any,
+      mockServicesPreferencesModel as any,
+      aPastOptOutEmailSwitchDate
+    );
+
+    const result: StoreMessageContentActivityResult = await storeMessageContentActivityHandler(
+      mockContext,
+      {
+        ...aCreatedMessageEvent,
+        message: {
+          ...aNewMessageWithoutContent,
+          senderServiceId: "01234567890" as ServiceId
+        }
+      }
+    );
+
+    expect(result.kind).toBe("FAILURE");
+    if (result.kind === "FAILURE") {
+      expect(result.reason).toEqual("SENDER_BLOCKED");
+    }
+
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
       aRetrievedProfile.fiscalCode
     ]);
 
@@ -652,7 +894,7 @@ describe("getStoreMessageContentActivityHandler", () => {
   });
 
   it("should return a failure if message sender service does not exists in user service preference (MANUAL SETTINGS)", async () => {
-    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
       taskEither.of(
         some({
           ...aRetrievedProfile,
@@ -693,9 +935,9 @@ describe("getStoreMessageContentActivityHandler", () => {
       expect(result.reason).toEqual("SENDER_BLOCKED");
     }
 
-    expect(findLastVersionByModelIdMock).toHaveBeenCalled();
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledTimes(1);
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledWith([
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
       aRetrievedProfile.fiscalCode
     ]);
 
@@ -713,13 +955,13 @@ describe("getStoreMessageContentActivityHandler", () => {
   });
 
   it("should return a success if message sender service exists and is enabled in user service preference (MANUAL SETTINGS)", async () => {
-    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
       taskEither.of(
         some({
           ...aRetrievedProfile,
           servicePreferencesSettings: manualProfileServicePreferencesSettings,
           blockedInboxOrChannels: {
-            "01234567890": [BlockedInboxOrChannelEnum.INBOX]
+            "01234567890": [BlockedInboxOrChannelEnum.INBOX] // this settings will not be checked because we are in MANUAL settings
           }
         })
       )
@@ -756,14 +998,81 @@ describe("getStoreMessageContentActivityHandler", () => {
 
     expect(result.kind).toBe("SUCCESS");
     if (result.kind === "SUCCESS") {
+      expect(result.blockedInboxOrChannels).toEqual([]);
+    }
+
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
+      aRetrievedProfile.fiscalCode
+    ]);
+
+    const documentId = makeServicesPreferencesDocumentId(
+      aRetrievedProfile.fiscalCode,
+      "01234567890" as NonEmptyString,
+      manualProfileServicePreferencesSettings.version as NonNegativeInteger
+    );
+    expect(findServicePreferenceMock).toHaveBeenCalled();
+    expect(findServicePreferenceMock).toHaveBeenCalledTimes(1);
+    expect(findServicePreferenceMock).toHaveBeenCalledWith([
+      documentId,
+      aRetrievedProfile.fiscalCode
+    ]);
+  });
+
+  it("should return a success with blocked EMAIL if message sender service exists and has EMAIL disabled in user service preference (MANUAL SETTINGS)", async () => {
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(
+        some({
+          ...aRetrievedProfile,
+          servicePreferencesSettings: manualProfileServicePreferencesSettings,
+          blockedInboxOrChannels: {
+            "01234567890": [BlockedInboxOrChannelEnum.INBOX] // this settings will not be checked because we are in MANUAL settings
+          }
+        })
+      )
+    );
+
+    findServicePreferenceMock.mockImplementationOnce(
+      ([modelId, partitionKey]) =>
+        taskEither.of<CosmosErrors, Option<ServicePreference>>(
+          some({
+            ...anEnabledServicePreference,
+            isEmailEnabled: false,
+            version: manualProfileServicePreferencesSettings.version
+          })
+        )
+    );
+
+    const storeMessageContentActivityHandler = getStoreMessageContentActivityHandler(
+      profileModelMock as any,
+      messageModelMock as any,
+      {} as any,
+      mockServicesPreferencesModel as any,
+      aPastOptOutEmailSwitchDate
+    );
+
+    const result: StoreMessageContentActivityResult = await storeMessageContentActivityHandler(
+      mockContext,
+      {
+        ...aCreatedMessageEvent,
+        message: {
+          ...aNewMessageWithoutContent,
+          senderServiceId: "01234567890" as ServiceId
+        }
+      }
+    );
+
+    expect(result.kind).toBe("SUCCESS");
+    if (result.kind === "SUCCESS") {
       expect(result.blockedInboxOrChannels).toEqual([
-        BlockedInboxOrChannelEnum.INBOX
+        BlockedInboxOrChannelEnum.EMAIL
       ]);
     }
 
-    expect(findLastVersionByModelIdMock).toHaveBeenCalled();
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledTimes(1);
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledWith([
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
       aRetrievedProfile.fiscalCode
     ]);
 
@@ -781,7 +1090,7 @@ describe("getStoreMessageContentActivityHandler", () => {
   });
 
   it("should return a failure if message sender service exists and is not enabled in user service preference (MANUAL SETTINGS)", async () => {
-    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
       taskEither.of(
         some({
           ...aRetrievedProfile,
@@ -827,9 +1136,76 @@ describe("getStoreMessageContentActivityHandler", () => {
       expect(result.reason).toEqual("SENDER_BLOCKED");
     }
 
-    expect(findLastVersionByModelIdMock).toHaveBeenCalled();
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledTimes(1);
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledWith([
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
+      aRetrievedProfile.fiscalCode
+    ]);
+
+    const documentId = makeServicesPreferencesDocumentId(
+      aRetrievedProfile.fiscalCode,
+      "01234567890" as NonEmptyString,
+      manualProfileServicePreferencesSettings.version as NonNegativeInteger
+    );
+    expect(findServicePreferenceMock).toHaveBeenCalled();
+    expect(findServicePreferenceMock).toHaveBeenCalledTimes(1);
+    expect(findServicePreferenceMock).toHaveBeenCalledWith([
+      documentId,
+      aRetrievedProfile.fiscalCode
+    ]);
+  });
+
+  it("should return a failure if message sender service exists and has INBOX disabled in user service preference (MANUAL SETTINGS)", async () => {
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(
+        some({
+          ...aRetrievedProfile,
+          servicePreferencesSettings: manualProfileServicePreferencesSettings,
+          blockedInboxOrChannels: {
+            "01234567890": [BlockedInboxOrChannelEnum.INBOX]
+          }
+        })
+      )
+    );
+
+    findServicePreferenceMock.mockImplementationOnce(
+      ([modelId, partitionKey]) =>
+        taskEither.of<CosmosErrors, Option<ServicePreference>>(
+          some({
+            ...anEnabledServicePreference,
+            isInboxEnabled: false,
+            version: manualProfileServicePreferencesSettings.version
+          })
+        )
+    );
+
+    const storeMessageContentActivityHandler = getStoreMessageContentActivityHandler(
+      profileModelMock as any,
+      messageModelMock as any,
+      {} as any,
+      mockServicesPreferencesModel as any,
+      aPastOptOutEmailSwitchDate
+    );
+
+    const result: StoreMessageContentActivityResult = await storeMessageContentActivityHandler(
+      mockContext,
+      {
+        ...aCreatedMessageEvent,
+        message: {
+          ...aNewMessageWithoutContent,
+          senderServiceId: "01234567890" as ServiceId
+        }
+      }
+    );
+
+    expect(result.kind).toBe("FAILURE");
+    if (result.kind === "FAILURE") {
+      expect(result.reason).toEqual("SENDER_BLOCKED");
+    }
+
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
       aRetrievedProfile.fiscalCode
     ]);
 
@@ -847,7 +1223,7 @@ describe("getStoreMessageContentActivityHandler", () => {
   });
 
   it("should return a failure if message sender service exists in profile.blockedInboxOrChannels (LEGACY SETTINGS)", async () => {
-    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
       taskEither.of(
         some({
           ...aRetrievedProfile,
@@ -886,16 +1262,16 @@ describe("getStoreMessageContentActivityHandler", () => {
     // findServicePreferenceMock is not mocked because it should not be called
     // senderServiceId: "01234567890" is in blockedInboxOrChannels
     // => FAILURE
-    expect(findLastVersionByModelIdMock).toHaveBeenCalled();
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledTimes(1);
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledWith([
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
       aRetrievedProfile.fiscalCode
     ]);
     expect(findServicePreferenceMock).not.toHaveBeenCalled();
   });
 
   it("should return a success if message sender service does not exists in profile.blockedInboxOrChannels (LEGACY SETTINGS)", async () => {
-    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
       taskEither.of(
         some({
           ...aRetrievedProfile,
@@ -934,9 +1310,59 @@ describe("getStoreMessageContentActivityHandler", () => {
     // findServicePreferenceMock is not mocked because it should not be called
     // senderServiceId: "01234567890" is not in blockedInboxOrChannels
     // => SUCCESS
-    expect(findLastVersionByModelIdMock).toHaveBeenCalled();
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledTimes(1);
-    expect(findLastVersionByModelIdMock).toHaveBeenCalledWith([
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
+      aRetrievedProfile.fiscalCode
+    ]);
+    expect(findServicePreferenceMock).not.toHaveBeenCalled();
+  });
+
+  it("should return a success if message sender service exists in profile.blockedInboxOrChannels but only blocks EMAIL (LEGACY SETTINGS)", async () => {
+    findLastProfileVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(
+        some({
+          ...aRetrievedProfile,
+          servicePreferencesSettings: legacyProfileServicePreferencesSettings,
+          blockedInboxOrChannels: {
+            "01234567890": [BlockedInboxOrChannelEnum.EMAIL]
+          }
+        })
+      )
+    );
+
+    const storeMessageContentActivityHandler = getStoreMessageContentActivityHandler(
+      profileModelMock as any,
+      messageModelMock as any,
+      {} as any,
+      mockServicesPreferencesModel as any,
+      aPastOptOutEmailSwitchDate
+    );
+
+    const result: StoreMessageContentActivityResult = await storeMessageContentActivityHandler(
+      mockContext,
+      {
+        ...aCreatedMessageEvent,
+        message: {
+          ...aNewMessageWithoutContent,
+          senderServiceId: "01234567890" as ServiceId
+        }
+      }
+    );
+
+    expect(result.kind).toBe("SUCCESS");
+    if (result.kind === "SUCCESS") {
+      expect(result.blockedInboxOrChannels).toEqual([
+        BlockedInboxOrChannelEnum.EMAIL
+      ]);
+    }
+
+    // findServicePreferenceMock is not mocked because it should not be called
+    // senderServiceId: "01234567890" is not in blockedInboxOrChannels
+    // => SUCCESS
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalled();
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastProfileVersionByModelIdMock).toHaveBeenCalledWith([
       aRetrievedProfile.fiscalCode
     ]);
     expect(findServicePreferenceMock).not.toHaveBeenCalled();

--- a/StoreMessageContentActivity/handler.ts
+++ b/StoreMessageContentActivity/handler.ts
@@ -67,7 +67,7 @@ export type StoreMessageContentActivityResult = t.TypeOf<
 >;
 
 export const ServicePreferenceError = t.interface({
-  kind: t.keyof({ LEGACY: null, ERROR: null }),
+  kind: t.keyof({ ERROR: null, LEGACY: null }),
   message: t.string
 });
 
@@ -213,16 +213,12 @@ export const getStoreMessageContentActivityHandler = (
     .fold<boolean>(servicePreferenceError => {
       if (servicePreferenceError.kind === "ERROR") {
         // The query has failed, we consider this as a transient error.
-        context.log.error(
-          `${logPrefix}|${servicePreferenceError.message}`
-        );
+        context.log.error(`${logPrefix}|${servicePreferenceError.message}`);
         throw Error("Error while retrieving user's service preference");
       }
 
       // an error occurs also when user service preference mode is LEGACY
-      context.log.warn(
-        `${logPrefix}|${servicePreferenceError.message}`
-      );
+      context.log.warn(`${logPrefix}|${servicePreferenceError.message}`);
 
       // whether the user has blocked inbox storage for messages from this sender
       const isMessageStorageBlockedForService =

--- a/StoreMessageContentActivity/handler.ts
+++ b/StoreMessageContentActivity/handler.ts
@@ -92,8 +92,8 @@ type ServicePreferencesValues = Omit<
 const channelToBlockedInboxOrChannelEnum: {
   readonly [key in keyof ServicePreferencesValues]: BlockedInboxOrChannelEnum;
 } = {
-  isInboxEnabled: BlockedInboxOrChannelEnum.INBOX,
   isEmailEnabled: BlockedInboxOrChannelEnum.EMAIL,
+  isInboxEnabled: BlockedInboxOrChannelEnum.INBOX,
   isWebhookEnabled: BlockedInboxOrChannelEnum.WEBHOOK
 };
 

--- a/StoreMessageContentActivity/index.ts
+++ b/StoreMessageContentActivity/index.ts
@@ -9,10 +9,13 @@ import {
   PROFILE_COLLECTION_NAME,
   ProfileModel
 } from "@pagopa/io-functions-commons/dist/src/models/profile";
+import {
+  ServicesPreferencesModel,
+  SERVICE_PREFERENCES_COLLECTION_NAME
+} from "@pagopa/io-functions-commons/dist/src/models/service_preference";
 import { cosmosdbInstance } from "../utils/cosmosdb";
 import { getConfigOrThrow } from "../utils/config";
 import { getStoreMessageContentActivityHandler } from "./handler";
-import { ServicesPreferencesModel, SERVICE_PREFERENCES_COLLECTION_NAME } from "@pagopa/io-functions-commons/dist/src/models/service_preference";
 
 const config = getConfigOrThrow();
 

--- a/StoreMessageContentActivity/index.ts
+++ b/StoreMessageContentActivity/index.ts
@@ -12,6 +12,7 @@ import {
 import { cosmosdbInstance } from "../utils/cosmosdb";
 import { getConfigOrThrow } from "../utils/config";
 import { getStoreMessageContentActivityHandler } from "./handler";
+import { ServicesPreferencesModel, SERVICE_PREFERENCES_COLLECTION_NAME } from "@pagopa/io-functions-commons/dist/src/models/service_preference";
 
 const config = getConfigOrThrow();
 
@@ -26,10 +27,16 @@ const messageModel = new MessageModel(
 
 const blobService = createBlobService(config.QueueStorageConnection);
 
+const servicePreferencesModel = new ServicesPreferencesModel(
+  cosmosdbInstance.container(SERVICE_PREFERENCES_COLLECTION_NAME),
+  SERVICE_PREFERENCES_COLLECTION_NAME
+);
+
 const activityFunctionHandler: AzureFunction = getStoreMessageContentActivityHandler(
   profileModel,
   messageModel,
-  blobService
+  blobService,
+  servicePreferencesModel
 );
 
 export default activityFunctionHandler;

--- a/__mocks__/mocks.ts
+++ b/__mocks__/mocks.ts
@@ -24,7 +24,8 @@ import { TimeToLiveSeconds } from "@pagopa/io-functions-commons/dist/generated/d
 import { NewMessageWithoutContent, RetrievedMessageWithoutContent } from "@pagopa/io-functions-commons/dist/src/models/message";
 import { CreatedMessageEventSenderMetadata } from "@pagopa/io-functions-commons/dist/src/models/created_message_sender_metadata";
 import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/profile";
-import { ServicesPreferencesModeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServicesPreferencesMode";
+import { ServicesPreferencesModeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServicesPreferencesMode"
+import { ServicePreference } from "@pagopa/io-functions-commons/dist/src/models/service_preference"
 import { MessageContent } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageContent";
 
 export const aFiscalCode = "AAABBB01C02D345D" as FiscalCode;
@@ -82,6 +83,16 @@ export const anIncompleteService: Service & {
 export const legacyProfileServicePreferencesSettings: RetrievedProfile["servicePreferencesSettings"] = {
   mode: ServicesPreferencesModeEnum.LEGACY,
   version: -1
+};
+
+export const autoProfileServicePreferencesSettings: RetrievedProfile["servicePreferencesSettings"] = {
+  mode: ServicesPreferencesModeEnum.AUTO,
+  version: 0 as NonNegativeInteger
+};
+
+export const manualProfileServicePreferencesSettings: RetrievedProfile["servicePreferencesSettings"] = {
+  mode: ServicesPreferencesModeEnum.MANUAL,
+  version: 1 as NonNegativeInteger
 };
 
 export const aRetrievedProfile: RetrievedProfile = {
@@ -148,3 +159,22 @@ export const aCreatedMessageEventSenderMetadata: CreatedMessageEventSenderMetada
   serviceName: "A_SERVICE_NAME" as NonEmptyString,
   serviceUserEmail: "aaa@mail.com" as EmailString
 };
+
+export const anEnabledServicePreference: ServicePreference = {
+  fiscalCode: aFiscalCode,
+  isEmailEnabled: true,
+  isInboxEnabled: true,
+  isWebhookEnabled: true,
+  serviceId: "01234567890" as NonEmptyString,
+  settingsVersion: 0 as NonNegativeInteger
+}
+
+
+export const aDisabledServicePreference: ServicePreference = {
+  fiscalCode: aFiscalCode,
+  isEmailEnabled: false,
+  isInboxEnabled: false,
+  isWebhookEnabled: false,
+  serviceId: "01234567890" as NonEmptyString,
+  settingsVersion: 0 as NonNegativeInteger
+} 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@azure/cosmos": "^3.7.2",
-    "@pagopa/io-functions-commons": "^20.5.2",
+    "@pagopa/io-functions-commons": "^20.6.5",
     "@pagopa/ts-commons": "^9.4.1",
     "applicationinsights": "^1.7.4",
     "azure-storage": "^2.10.3",
@@ -77,6 +77,7 @@
   },
   "resolutions": {
     "handlebars": "~4.5.3",
-    "fp-ts": "1.17.4"
+    "fp-ts": "1.17.4",
+    "@azure/cosmos": "3.11.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@azure/cosmos": "^3.7.2",
-    "@pagopa/io-functions-commons": "^20.6.5",
+    "@pagopa/io-functions-commons": "^20.6.6",
     "@pagopa/ts-commons": "^9.4.1",
     "applicationinsights": "^1.7.4",
     "azure-storage": "^2.10.3",

--- a/utils/__tests__/arbitraries.ts
+++ b/utils/__tests__/arbitraries.ts
@@ -240,7 +240,7 @@ export const retrievedProfileArb = fc
         version: version as NonNegativeInteger,
         servicePreferencesSettings: {
           mode: ServicesPreferencesModeEnum.LEGACY,
-          version: 0
+          version: -1
         }
       } as RetrievedProfile)
   );
@@ -273,7 +273,7 @@ export const retrievedProfileUnhandled = fc.tuple(retrievedProfileArb).map(
       ...profile,
       servicePreferencesSettings: {
         mode: ServicesPreferencesModeEnum.AUTO,
-        version: 0
+        version: -1
       }
     } as RetrievedProfile)
 );

--- a/utils/__tests__/arbitraries.ts
+++ b/utils/__tests__/arbitraries.ts
@@ -8,6 +8,7 @@ import { ClientIp } from "@pagopa/io-functions-commons/dist/src/utils/middleware
 import * as assert from "assert";
 import * as fc from "fast-check";
 import { some } from "fp-ts/lib/Option";
+import { ServicesPreferencesModeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServicesPreferencesMode";
 import {
   NonNegativeInteger,
   WithinRangeInteger
@@ -18,6 +19,7 @@ import {
   NonEmptyString,
   PatternString
 } from "italia-ts-commons/lib/strings";
+import { RetrievedServicePreference } from "@pagopa/io-functions-commons/dist/src/models/service_preference";
 
 //
 // custom fastcheck arbitraries
@@ -234,6 +236,23 @@ export const retrievedProfileArb = fc
         isInboxEnabled: true,
         kind: "IRetrievedProfile",
         preferredLanguages: [PreferredLanguageEnum.en_GB],
-        version: version as NonNegativeInteger
+        version: version as NonNegativeInteger,
+        servicePreferencesSettings: {
+          mode: ServicesPreferencesModeEnum.LEGACY,
+          version: 0
+        }
       } as RetrievedProfile)
+  );
+
+export const retrievedServicesPreferencesArb = fc
+  .tuple(fc.nat(), fiscalCodeArb, fc.emailAddress())
+  .map(
+    ([version, fiscalCode, email]) =>
+      ({
+        _etag: "_etag",
+        _rid: "_rid",
+        _self: "xyz",
+        _ts: 1,
+        isEmailEnabled: true
+      } as RetrievedServicePreference)
   );

--- a/utils/__tests__/arbitraries.ts
+++ b/utils/__tests__/arbitraries.ts
@@ -20,6 +20,7 @@ import {
   PatternString
 } from "italia-ts-commons/lib/strings";
 import { RetrievedServicePreference } from "@pagopa/io-functions-commons/dist/src/models/service_preference";
+import { ServiceId } from "../../generated/api-admin/ServiceId";
 
 //
 // custom fastcheck arbitraries
@@ -244,6 +245,39 @@ export const retrievedProfileArb = fc
       } as RetrievedProfile)
   );
 
+export const retrievedProfileAuto = fc.tuple(retrievedProfileArb).map(
+  ([profile]) =>
+    ({
+      ...profile,
+      servicePreferencesSettings: {
+        mode: ServicesPreferencesModeEnum.AUTO,
+        version: 1
+      }
+    } as RetrievedProfile)
+);
+
+export const retrievedProfileManual = fc.tuple(retrievedProfileArb).map(
+  ([profile]) =>
+    ({
+      ...profile,
+      servicePreferencesSettings: {
+        mode: ServicesPreferencesModeEnum.MANUAL,
+        version: 1
+      }
+    } as RetrievedProfile)
+);
+
+export const retrievedProfileUnhandled = fc.tuple(retrievedProfileArb).map(
+  ([profile]) =>
+    ({
+      ...profile,
+      servicePreferencesSettings: {
+        mode: ServicesPreferencesModeEnum.AUTO,
+        version: 0
+      }
+    } as RetrievedProfile)
+);
+
 export const retrievedServicesPreferencesArb = fc
   .tuple(fc.nat(), fiscalCodeArb, fc.emailAddress())
   .map(
@@ -253,6 +287,27 @@ export const retrievedServicesPreferencesArb = fc
         _rid: "_rid",
         _self: "xyz",
         _ts: 1,
-        isEmailEnabled: true
+        isInboxEnabled: true
+      } as RetrievedServicePreference)
+  );
+
+export const retrievedServicesPreferencesEnabled = fc
+  .tuple(retrievedServicesPreferencesArb)
+  .map(
+    ([prefs]) =>
+      ({
+        ...prefs,
+        settingsVersion: 1,
+        serviceId: "1" as ServiceId
+      } as RetrievedServicePreference)
+  );
+
+export const retrievedServicesPreferencesDisabled = fc
+  .tuple(retrievedServicesPreferencesEnabled)
+  .map(
+    ([prefs]) =>
+      ({
+        ...prefs,
+        isInboxEnabled: false
       } as RetrievedServicePreference)
   );

--- a/utils/__tests__/profile.test.ts
+++ b/utils/__tests__/profile.test.ts
@@ -5,7 +5,10 @@ import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import { BlockedInboxOrChannelEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
 
 import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/profile";
-import { isSenderAllowed, retrievedProfileToLimitedProfile } from "../profile";
+import {
+  isSenderAllowed,
+  retrievedProfileToLimitedProfile
+} from "../profile-services";
 import { retrievedProfileArb } from "./arbitraries";
 
 describe("isSenderAllowed", () => {

--- a/utils/__tests__/profiles-services.test.ts
+++ b/utils/__tests__/profiles-services.test.ts
@@ -277,7 +277,7 @@ describe("profiles-services-test", () => {
     );
   });
 
-  it("GIVEN a profile with setting preference verison to 0 and service preference mode to AUTO, WHEN handleAll is called, THEN the handler must return a NotFound", async () => {
+  it("GIVEN a profile with setting preference verison to -1 and service preference mode to AUTO, WHEN handleAll is called, THEN the handler must return a NotFound", async () => {
     await fc.assert(
       fc.asyncProperty(
         arb.retrievedProfileUnhandled,

--- a/utils/__tests__/profiles-services.test.ts
+++ b/utils/__tests__/profiles-services.test.ts
@@ -1,0 +1,305 @@
+import * as e from "fp-ts/lib/Either";
+import * as te from "fp-ts/lib/TaskEither";
+import * as t from "fp-ts/lib/Task";
+import * as a from "fp-ts/lib/Array";
+import {
+  handleAll,
+  profileWithPreferenceVersionWithModeAuto,
+  profileWithPreferenceVersionWithModeManual,
+  profileWithModeLegacy
+} from "../profile-services";
+import * as arb from "./arbitraries";
+import * as fc from "fast-check";
+import {
+  ServicesPreferencesModel,
+  RetrievedServicePreference
+} from "@pagopa/io-functions-commons/dist/src/models/service_preference";
+import { Errors, Validation } from "io-ts";
+import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
+
+describe("profiles-services-test", () => {
+  it("test sequence with task", async () => {
+    const result = await a.array
+      .sequence(t.taskSeq)([
+        t.task.of<e.Either<string, string>>(e.right("OK")),
+        t.task.of(e.left("KO"))
+      ])
+      .run();
+    expect(result.some(e.isRight)).toBe(true);
+    expect(result.some(e.isLeft)).toBe(true);
+    expect(result.find(e.isRight).value).toBe("OK");
+  });
+
+  const getServicesPreferencesResults = (
+    servicePref: RetrievedServicePreference
+  ): AsyncIterable<ReadonlyArray<Validation<RetrievedServicePreference>>> => ({
+    async *[Symbol.asyncIterator]() {
+      yield [e.right<Errors, RetrievedServicePreference>(servicePref)];
+    }
+  });
+
+  it("GIVEN a valid profile with service preference mode to AUTO, WHEN profileWithPreferenceVersionWithModeAuto is called, THEN the handler must return a LimitedProfile allowing sending message", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arb.retrievedProfileAuto,
+        arb.retrievedServicesPreferencesEnabled,
+        async (profile, servicePref) => {
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() =>
+              getServicesPreferencesResults(servicePref)
+            )
+          } as unknown) as ServicesPreferencesModel;
+          const handlerCheck = profileWithPreferenceVersionWithModeAuto.isMyReposability(
+            profile
+          );
+          expect(handlerCheck).toBe(true);
+          const handlerExec = await profileWithPreferenceVersionWithModeAuto
+            .handleProfile(
+              profile,
+              mockServicesPreferencesModel,
+              "1" as ServiceId
+            )
+            .run();
+          expect(handlerExec.sender_allowed).toBe(true);
+        }
+      )
+    );
+  });
+
+  it("GIVEN a profile missing service-preferences with service preference mode to AUTO, WHEN profileWithPreferenceVersionWithModeAuto is called, THEN the handler must return a LimitedProfile allowing sending message", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arb.retrievedProfileAuto,
+        arb.retrievedServicesPreferencesEnabled,
+        async (profile, servicePref) => {
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => te.fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
+          const handlerCheck = profileWithPreferenceVersionWithModeAuto.isMyReposability(
+            profile
+          );
+          expect(handlerCheck).toBe(true);
+          const handlerExec = await profileWithPreferenceVersionWithModeAuto
+            .handleProfile(
+              profile,
+              mockServicesPreferencesModel,
+              "1" as ServiceId
+            )
+            .run();
+          expect(handlerExec.sender_allowed).toBe(true);
+        }
+      )
+    );
+  });
+
+  it("GIVEN a not enabled profile with service preference mode to AUTO, WHEN profileWithPreferenceVersionWithModeAuto is called, THE the handler must return a LimitedProfile not allowing sending message", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arb.retrievedProfileAuto,
+        arb.retrievedServicesPreferencesDisabled,
+        async (profile, servicePref) => {
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() =>
+              getServicesPreferencesResults(servicePref)
+            )
+          } as unknown) as ServicesPreferencesModel;
+          const handlerCheck = profileWithPreferenceVersionWithModeAuto.isMyReposability(
+            profile
+          );
+          expect(handlerCheck).toBe(true);
+          const handlerExec = await profileWithPreferenceVersionWithModeAuto
+            .handleProfile(
+              profile,
+              mockServicesPreferencesModel,
+              "1" as ServiceId
+            )
+            .run();
+          expect(handlerExec.sender_allowed).toBe(false);
+        }
+      )
+    );
+  });
+
+  it("GIVEN a valid profile with service preference mode to MANUAL, WHEN profileWithPreferenceVersionWithModeManual is called, THEN the handler must return a LimitedProfile allowing sending message", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arb.retrievedProfileManual,
+        arb.retrievedServicesPreferencesEnabled,
+        async (profile, servicePref) => {
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() =>
+              getServicesPreferencesResults(servicePref)
+            )
+          } as unknown) as ServicesPreferencesModel;
+          const handlerCheck = profileWithPreferenceVersionWithModeManual.isMyReposability(
+            profile
+          );
+          expect(handlerCheck).toBe(true);
+          const handlerExec = await profileWithPreferenceVersionWithModeManual
+            .handleProfile(
+              profile,
+              mockServicesPreferencesModel,
+              "1" as ServiceId
+            )
+            .run();
+          expect(handlerExec.sender_allowed).toBe(true);
+        }
+      )
+    );
+  });
+
+  it("GIVEN a profile missing service-preferences with service preference mode to MANUAL, WHEN profileWithPreferenceVersionWithModeManual is called, THEN the handler must return a LimitedProfile not allowing sending message", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arb.retrievedProfileManual,
+        arb.retrievedServicesPreferencesEnabled,
+        async (profile, servicePref) => {
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => te.fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
+          const handlerCheck = profileWithPreferenceVersionWithModeManual.isMyReposability(
+            profile
+          );
+          expect(handlerCheck).toBe(true);
+          const handlerExec = await profileWithPreferenceVersionWithModeManual
+            .handleProfile(
+              profile,
+              mockServicesPreferencesModel,
+              "1" as ServiceId
+            )
+            .run();
+          expect(handlerExec.sender_allowed).toBe(false);
+        }
+      )
+    );
+  });
+
+  it("GIVEN a not enabled profile with service preference mode to MANUAL, WHEN profileWithPreferenceVersionWithModeManual is called, THE the handler must return a LimitedProfile not allowing sending message", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arb.retrievedProfileManual,
+        arb.retrievedServicesPreferencesDisabled,
+        async (profile, servicePref) => {
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() =>
+              getServicesPreferencesResults(servicePref)
+            )
+          } as unknown) as ServicesPreferencesModel;
+          const handlerCheck = profileWithPreferenceVersionWithModeManual.isMyReposability(
+            profile
+          );
+          expect(handlerCheck).toBe(true);
+          const handlerExec = await profileWithPreferenceVersionWithModeManual
+            .handleProfile(
+              profile,
+              mockServicesPreferencesModel,
+              "1" as ServiceId
+            )
+            .run();
+          expect(handlerExec.sender_allowed).toBe(false);
+        }
+      )
+    );
+  });
+
+  it("GIVEN a valid profile with service preference mode to LEGACY, WHEN profileWithModeLegacy is called, THEN the handler must return a LimitedProfile allowing sending message", async () => {
+    await fc.assert(
+      fc.asyncProperty(arb.retrievedProfileArb, async profile => {
+        const mockServicesPreferencesModel = ({
+          getQueryIterator: jest.fn(() => te.fromLeft({}))
+        } as unknown) as ServicesPreferencesModel;
+        const handlerCheck = profileWithModeLegacy.isMyReposability(profile);
+        expect(
+          mockServicesPreferencesModel.getQueryIterator
+        ).not.toHaveBeenCalled();
+        expect(handlerCheck).toBe(true);
+        const handlerExec = await profileWithModeLegacy
+          .handleProfile(
+            profile,
+            mockServicesPreferencesModel,
+            "1" as ServiceId
+          )
+          .run();
+        expect(handlerExec.sender_allowed).toBe(true);
+      })
+    );
+  });
+
+  it("GIVEN a profile missing service-preferences with service preference mode to AUTO, WHEN handleAll is called, THEN the handler must return a LimitedProfile allowing sending message", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arb.retrievedProfileAuto,
+        arb.retrievedServicesPreferencesEnabled,
+        async (profile, servicePref) => {
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => te.fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
+          const handlerExec = await handleAll()(
+            profile,
+            mockServicesPreferencesModel,
+            "1" as ServiceId
+          ).run();
+          expect(
+            mockServicesPreferencesModel.getQueryIterator
+          ).toHaveBeenCalled();
+          expect(handlerExec.isRight()).toBe(true);
+          expect(
+            handlerExec.getOrElse({ sender_allowed: false }).sender_allowed
+          ).toBe(true);
+        }
+      )
+    );
+  });
+
+  it("GIVEN a profile missing service-preferences with service preference mode to MANUAL, WHEN handleAll is called, THEN the handler must return a LimitedProfile not allowing sending message", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arb.retrievedProfileManual,
+        arb.retrievedServicesPreferencesEnabled,
+        async (profile, servicePref) => {
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => te.fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
+          const handlerExec = await handleAll()(
+            profile,
+            mockServicesPreferencesModel,
+            "1" as ServiceId
+          ).run();
+          expect(
+            mockServicesPreferencesModel.getQueryIterator
+          ).toHaveBeenCalled();
+          expect(handlerExec.isRight()).toBe(true);
+          expect(
+            handlerExec.getOrElse({ sender_allowed: false }).sender_allowed
+          ).toBe(false);
+        }
+      )
+    );
+  });
+
+  it("GIVEN a profile with setting preference verison to 0 and service preference mode to AUTO, WHEN handleAll is called, THEN the handler must return a NotFound", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arb.retrievedProfileUnhandled,
+        arb.retrievedServicesPreferencesEnabled,
+        async (profile, servicePref) => {
+          const mockServicesPreferencesModel = ({
+            getQueryIterator: jest.fn(() => te.fromLeft({}))
+          } as unknown) as ServicesPreferencesModel;
+          const handlerExec = await handleAll()(
+            profile,
+            mockServicesPreferencesModel,
+            "1" as ServiceId
+          ).run();
+          expect(
+            mockServicesPreferencesModel.getQueryIterator
+          ).not.toHaveBeenCalled();
+          expect(handlerExec.isLeft()).toBe(true);
+          expect(handlerExec.swap().getOrElse(undefined).kind).toBe(
+            "IResponseErrorNotFound"
+          );
+        }
+      )
+    );
+  });
+});

--- a/utils/profile-services.ts
+++ b/utils/profile-services.ts
@@ -1,0 +1,217 @@
+import { LimitedProfile } from "@pagopa/io-functions-commons/dist/generated/definitions/LimitedProfile";
+import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/profile";
+import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
+import {
+  RetrievedServicePreference,
+  ServicesPreferencesModel
+} from "@pagopa/io-functions-commons/dist/src/models/service_preference";
+import { asyncIterableToArray } from "@pagopa/io-functions-commons/dist/src/utils/async";
+import {
+  IResponseErrorNotFound,
+  ResponseErrorFromValidationErrors,
+  ResponseErrorNotFound
+} from "italia-ts-commons/lib/responses";
+import * as e from "fp-ts/lib/Either";
+import * as te from "fp-ts/lib/TaskEither";
+import * as t from "fp-ts/lib/Task";
+import { ServicesPreferencesModeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServicesPreferencesMode";
+import * as a from "fp-ts/lib/Array";
+import { IResponseErrorValidation } from "@pagopa/ts-commons/lib/responses";
+import { BlockedInboxOrChannelEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
+import { TaskEither } from "fp-ts/lib/TaskEither";
+
+const NOT_FOUND_TITLE = "ServicesPreferences not found";
+
+interface IServicePreferenceHandler {
+  readonly isMyReposability: (profile: RetrievedProfile) => boolean;
+  readonly handleProfile: (
+    profile: RetrievedProfile,
+    servicesPreferencesModel: ServicesPreferencesModel,
+    serviceId: ServiceId
+  ) => t.Task<LimitedProfile>;
+}
+
+const missingServicePreference = ResponseErrorNotFound(
+  NOT_FOUND_TITLE,
+  "The ServicesPreferences you requested was not found in the system."
+);
+
+/**
+ * Converts the RetrievedProfile model to LimitedProfile type.
+ */
+export const retrievedProfileToLimitedProfile = (
+  retrivedProfile: RetrievedProfile,
+  senderAllowed: boolean
+): LimitedProfile => ({
+  preferred_languages: retrivedProfile.preferredLanguages,
+  sender_allowed: senderAllowed
+});
+
+/**
+ * Whether the sender service is allowed to send
+ * messages to the user identified by this profile
+ */
+export const isSenderAllowed = (
+  blockedInboxOrChannels:
+    | RetrievedProfile["blockedInboxOrChannels"]
+    | undefined,
+  serviceId: ServiceId
+): boolean =>
+  blockedInboxOrChannels === undefined ||
+  blockedInboxOrChannels[serviceId] === undefined ||
+  blockedInboxOrChannels[serviceId].indexOf(BlockedInboxOrChannelEnum.INBOX) <
+    0;
+
+const findServicePreference = (
+  servicesPreferencesModel: ServicesPreferencesModel,
+  profile,
+  serviceId: ServiceId
+): te.TaskEither<IResponseErrorNotFound, RetrievedServicePreference> =>
+  te
+    .tryCatch(
+      () =>
+        asyncIterableToArray(
+          servicesPreferencesModel.getQueryIterator({
+            parameters: [
+              {
+                name: "@fiscalCode",
+                value: profile.fiscalCode
+              },
+              {
+                name: "@settingsVersion",
+                value: profile.servicePreferencesSettings.version
+              },
+              {
+                name: "@serviceId",
+                value: serviceId
+              }
+            ],
+            query: `
+                SELECT *
+                FROM c 
+                WHERE 
+                  c.fiscalCode = @fiscalCode 
+                  AND 
+                  c.settingsVersion = @settingsVersion
+                  AND
+                  c.serviceId = @serviceId
+              `
+          })
+        ),
+      () => missingServicePreference
+    )
+    .chain(preferences =>
+      te.fromEither(
+        a.fold<
+          e.Either<IResponseErrorValidation, RetrievedServicePreference>,
+          e.Either<IResponseErrorNotFound, RetrievedServicePreference>
+        >(
+          preferences
+            .reduce((acc, val) => acc.concat(val), [])
+            .map(pref =>
+              pref.mapLeft(
+                ResponseErrorFromValidationErrors(RetrievedServicePreference)
+              )
+            ),
+          e.left(missingServicePreference),
+          (h, _t) =>
+            h.mapLeft(_errors =>
+              ResponseErrorNotFound(
+                NOT_FOUND_TITLE,
+                "Can not decode the RetrievedServicePreference"
+              )
+            )
+        )
+      )
+    );
+
+const servicePreferenceToLimitedProfile = (
+  profile: RetrievedProfile,
+  servicePreference: RetrievedServicePreference
+): LimitedProfile =>
+  retrievedProfileToLimitedProfile(profile, servicePreference.isInboxEnabled);
+
+export const profileWithPreferenceVersionWithModeAuto: IServicePreferenceHandler = {
+  handleProfile: (profile, servicesPreferencesModel, serviceId) =>
+    findServicePreference(servicesPreferencesModel, profile, serviceId).fold(
+      _l => retrievedProfileToLimitedProfile(profile, true),
+      servicePreference =>
+        servicePreferenceToLimitedProfile(profile, servicePreference)
+    ),
+  isMyReposability: profile =>
+    profile.servicePreferencesSettings.version > 0 &&
+    profile.servicePreferencesSettings.mode === ServicesPreferencesModeEnum.AUTO
+};
+
+export const profileWithPreferenceVersionWithModeManual: IServicePreferenceHandler = {
+  handleProfile: (profile, servicesPreferencesModel, serviceId) =>
+    findServicePreference(servicesPreferencesModel, profile, serviceId).fold(
+      _l => retrievedProfileToLimitedProfile(profile, false),
+      servicePreference =>
+        servicePreferenceToLimitedProfile(profile, servicePreference)
+    ),
+  isMyReposability: profile =>
+    profile.servicePreferencesSettings.version > 0 &&
+    profile.servicePreferencesSettings.mode ===
+      ServicesPreferencesModeEnum.MANUAL
+};
+
+export const profileWithModeLegacy: IServicePreferenceHandler = {
+  handleProfile: (profile, _servicesPreferencesModel, serviceId) =>
+    t.task.of(
+      retrievedProfileToLimitedProfile(
+        profile,
+        isSenderAllowed(profile.blockedInboxOrChannels, serviceId)
+      )
+    ),
+  isMyReposability: profile =>
+    profile.servicePreferencesSettings.mode ===
+    ServicesPreferencesModeEnum.LEGACY
+};
+
+export const handle = (handler: IServicePreferenceHandler) => (
+  profile: RetrievedProfile,
+  servicesPreferencesModel: ServicesPreferencesModel,
+  serviceId: ServiceId
+): t.Task<e.Either<Error, LimitedProfile>> =>
+  te
+    .fromPredicate(
+      handler.isMyReposability,
+      _ => new Error("Handler not feasable!")
+    )(profile)
+    .chain(_ =>
+      te.right(
+        handler.handleProfile(profile, servicesPreferencesModel, serviceId)
+      )
+    )
+    .fold(
+      l => e.left(l),
+      r => e.right(r)
+    );
+
+export const handleAll = () => (
+  profile: RetrievedProfile,
+  servicesPreferencesModel: ServicesPreferencesModel,
+  serviceId: ServiceId
+): te.TaskEither<IResponseErrorNotFound, LimitedProfile> =>
+  new TaskEither(
+    a.array
+      .sequence(t.taskSeq)(
+        [
+          handle(profileWithPreferenceVersionWithModeAuto),
+          handle(profileWithPreferenceVersionWithModeManual),
+          handle(profileWithModeLegacy)
+        ].map(h => h(profile, servicesPreferencesModel, serviceId))
+      )
+      .map(results =>
+        a.findFirst(results, e.isRight).map(result => result.value)
+      ) // TODO: concat errors and return an either instead of an option
+      .map(
+        e.fromOption(
+          ResponseErrorNotFound(
+            NOT_FOUND_TITLE,
+            "Missing a feasable profile-service handler!"
+          )
+        )
+      )
+  );

--- a/utils/profile-services.ts
+++ b/utils/profile-services.ts
@@ -139,7 +139,7 @@ export const profileWithPreferenceVersionWithModeAuto: IServicePreferenceHandler
         servicePreferenceToLimitedProfile(profile, servicePreference)
     ),
   isMyReposability: profile =>
-    profile.servicePreferencesSettings.version > 0 &&
+    profile.servicePreferencesSettings.version >= 0 &&
     profile.servicePreferencesSettings.mode === ServicesPreferencesModeEnum.AUTO
 };
 
@@ -151,7 +151,7 @@ export const profileWithPreferenceVersionWithModeManual: IServicePreferenceHandl
         servicePreferenceToLimitedProfile(profile, servicePreference)
     ),
   isMyReposability: profile =>
-    profile.servicePreferencesSettings.version > 0 &&
+    profile.servicePreferencesSettings.version >= 0 &&
     profile.servicePreferencesSettings.mode ===
       ServicesPreferencesModeEnum.MANUAL
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -614,10 +614,10 @@
     eslint-plugin-sonarjs "^0.5.0"
     prettier "^2.1.2"
 
-"@pagopa/io-functions-commons@^20.6.5":
-  version "20.6.5"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-20.6.5.tgz#ca57a1263d4951eccb26cab124d24154e001c2a3"
-  integrity sha512-1D9pM8nRaho0jO0cQBd36/Ar3FH4lCBAj1433rzz5nck+9AnG2tRtn/sav23BaLQV/BRHvgDCaJvZ3NNxQJQ7w==
+"@pagopa/io-functions-commons@^20.6.6":
+  version "20.6.6"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-20.6.6.tgz#973027c4a51fd2f1f4a7218094f144faba40c875"
+  integrity sha512-SWxJpEW1KfHAE7WMfPUXnX0JOMJrupWNXItKyjx3tNmZw7EzfvRBfi7y4c2ysX0CpkcWq0hewhl8XT8ZEWH//w==
   dependencies:
     "@azure/cosmos" "^3.11.5"
     "@pagopa/ts-commons" "^9.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,7 +41,7 @@
     "@opentelemetry/api" "1.0.0-rc.0"
     tslib "^2.0.0"
 
-"@azure/cosmos@^3.11.1", "@azure/cosmos@^3.7.2":
+"@azure/cosmos@3.11.3", "@azure/cosmos@^3.11.5", "@azure/cosmos@^3.7.2":
   version "3.11.3"
   resolved "https://registry.yarnpkg.com/@azure/cosmos/-/cosmos-3.11.3.tgz#422db38bdafaaac50d01dd6a85306f40ef3fb6c2"
   integrity sha512-UaY6/87Jf4Pfqi1tEUhwJeaLzhpU0GajB55kU3UXs4bqQK+JPOUJXCe+TJtUD6vRd3RdwmoyoRF8k9cJ6LSQzQ==
@@ -614,24 +614,22 @@
     eslint-plugin-sonarjs "^0.5.0"
     prettier "^2.1.2"
 
-"@pagopa/io-functions-commons@^20.5.2":
-  version "20.5.2"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-20.5.2.tgz#8cce05a52b734e40649c6c9ec7843226319c8d67"
-  integrity sha512-3L3CML8CmaE6XwPL9+A64Pwpx/UP+6qwlThoWt1eAkCvKyGYSff5Wi8bO+NXTJaaiVr+352PEQ/D5W08WJ1VWg==
+"@pagopa/io-functions-commons@^20.6.5":
+  version "20.6.5"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-20.6.5.tgz#ca57a1263d4951eccb26cab124d24154e001c2a3"
+  integrity sha512-1D9pM8nRaho0jO0cQBd36/Ar3FH4lCBAj1433rzz5nck+9AnG2tRtn/sav23BaLQV/BRHvgDCaJvZ3NNxQJQ7w==
   dependencies:
-    "@azure/cosmos" "^3.11.1"
-    "@pagopa/ts-commons" "^9.4.1"
-    "@types/node-fetch" "^2.5.6"
+    "@azure/cosmos" "^3.11.5"
+    "@pagopa/ts-commons" "^9.5.1"
     applicationinsights "^1.8.10"
-    azure-storage "^2.10.3"
+    azure-storage "^2.10.4"
     cidr-matcher "^2.1.1"
     fp-ts "1.17.4"
     helmet "^4.6.0"
     helmet-csp "^2.5.1"
-    io-functions-express "^1.1.0"
     io-ts "1.8.5"
     node-fetch "^2.6.1"
-    nodemailer "^6.5.0"
+    nodemailer "^6.6.1"
     nodemailer-sendgrid "^1.0.3"
     referrer-policy "^1.1.0"
     rehype-stringify "^3.0.0"
@@ -682,6 +680,20 @@
     fp-ts "1.17.4"
     io-ts "1.8.5"
     json-set-map "^1.0.2"
+    node-fetch "^2.6.0"
+    validator "^10.1.0"
+
+"@pagopa/ts-commons@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@pagopa/ts-commons/-/ts-commons-9.5.1.tgz#a1285589265560a1a96b4d389da2e37f9209ec58"
+  integrity sha512-Eqozj079y/oyLZwh6I/WBWsUKJ6rFOj5wGTXaYmVffxFHWXstQiSqw5S6cFAKK5/LA9lL9ro+zk3+lUKi+/Fow==
+  dependencies:
+    abort-controller "^3.0.0"
+    agentkeepalive "^4.1.4"
+    applicationinsights "^1.8.10"
+    fp-ts "1.17.4"
+    io-ts "1.8.5"
+    json-set-map "^1.1.2"
     node-fetch "^2.6.0"
     validator "^10.1.0"
 
@@ -875,14 +887,6 @@
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"
   integrity sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==
-
-"@types/node-fetch@^2.5.6":
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.10.tgz#9b4d4a0425562f9fcea70b12cb3fcdd946ca8132"
-  integrity sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==
-  dependencies:
-    "@types/node" "*"
-    form-data "^3.0.0"
 
 "@types/node@*":
   version "15.0.2"
@@ -1154,7 +1158,7 @@ agent-base@6:
   dependencies:
     debug "4"
 
-agentkeepalive@^4.1.2:
+agentkeepalive@^4.1.2, agentkeepalive@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.1.4.tgz#d928028a4862cb11718e55227872e842a44c945b"
   integrity sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==
@@ -1163,7 +1167,7 @@ agentkeepalive@^4.1.2:
     depd "^1.1.2"
     humanize-ms "^1.2.1"
 
-ajv@^6.10.0, ajv@^6.12.4:
+ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.5.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -1171,17 +1175,6 @@ ajv@^6.10.0, ajv@^6.12.4:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^6.5.5:
-  version "6.12.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.1.tgz#cce4d7dfcd62d3c57b1cd772e688eff5f5cd3839"
-  integrity sha512-AUh2mDlJDAnzSRaKkMHopTD1GKwC1ApUq8oCzdjAOM5tavncgqWU+JoRu5Y3iYY0Q/euiU+1LWp0/O/QY8CcHw==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    opencollective-postinstall "^2.0.2"
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
@@ -1448,9 +1441,9 @@ aws-sign2@~0.7.0:
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
 aws4@^1.8.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
-  integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
+  integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
 axios@^0.19.0:
   version "0.19.2"
@@ -1459,10 +1452,10 @@ axios@^0.19.0:
   dependencies:
     follow-redirects "1.5.10"
 
-azure-storage@^2.10.3:
-  version "2.10.3"
-  resolved "https://registry.yarnpkg.com/azure-storage/-/azure-storage-2.10.3.tgz#c5966bf929d87587d78f6847040ea9a4b1d4a50a"
-  integrity sha512-IGLs5Xj6kO8Ii90KerQrrwuJKexLgSwYC4oLWmc11mzKe7Jt2E5IVg+ZQ8K53YWZACtVTMBNO3iGuA+4ipjJxQ==
+azure-storage@^2.10.3, azure-storage@^2.10.4:
+  version "2.10.4"
+  resolved "https://registry.yarnpkg.com/azure-storage/-/azure-storage-2.10.4.tgz#c481d207eabc05f57f019b209f7faa8737435104"
+  integrity sha512-zlfRPl4js92JC6+79C2EUmNGYjSknRl8pOiHQF78zy+pbOFOHtlBF6BU/OxPeHQX3gaa6NdEZnVydFxhhndkEw==
   dependencies:
     browserify-mime "~1.2.9"
     extend "^3.0.2"
@@ -1470,7 +1463,7 @@ azure-storage@^2.10.3:
     md5.js "1.3.4"
     readable-stream "~2.0.0"
     request "^2.86.0"
-    underscore "~1.8.3"
+    underscore "^1.12.1"
     uuid "^3.0.0"
     validator "~9.4.1"
     xml2js "0.2.8"
@@ -3109,9 +3102,9 @@ fast-check@^1.16.0:
     tslib "^2.0.0"
 
 fast-deep-equal@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
-  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-diff@^1.1.2:
   version "1.2.0"
@@ -3541,7 +3534,15 @@ har-schema@^2.0.0:
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
-har-validator@~5.1.0, har-validator@~5.1.3:
+har-validator@~5.1.0:
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
+  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
+  dependencies:
+    ajv "^6.12.3"
+    har-schema "^2.0.0"
+
+har-validator@~5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
   integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
@@ -3618,12 +3619,13 @@ has@^1.0.3:
     function-bind "^1.1.1"
 
 hash-base@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.0.4.tgz#5fc8686847ecd73499403319a6b0a3f3f6ae4918"
-  integrity sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
+  integrity sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==
   dependencies:
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
+    inherits "^2.0.4"
+    readable-stream "^3.6.0"
+    safe-buffer "^5.2.0"
 
 hast-util-is-element@^1.0.0:
   version "1.1.0"
@@ -3844,7 +3846,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3899,11 +3901,6 @@ io-functions-express@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/io-functions-express/-/io-functions-express-0.1.1.tgz#6ae954fe89ec1d797c5e5d10eca5e77f08ff4a4d"
   integrity sha512-Co7sovRyB0lxgU6NFh5v72Apude3XbgKQtqA7slryvKoEqLAvlnLU7DtsYVoF62O3ZJdtSHYf9JWuhDc/di1mg==
-
-io-functions-express@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/io-functions-express/-/io-functions-express-1.1.2.tgz#3025242c2096e443a889c7eb8cb7555fb7f1e5c6"
-  integrity sha512-Gy+g5QQ7k+WnG9TpbgHXObIKrIj05iY/0uK86k+rTyTg6JF9YXVWCnKKmxX2LsJqLpWQtdwOQSwRQhNSfs/rxg==
 
 io-ts@1.8.5:
   version "1.8.5"
@@ -4840,7 +4837,7 @@ json-schema@0.2.3:
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
-json-set-map@^1.0.2:
+json-set-map@^1.0.2, json-set-map@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/json-set-map/-/json-set-map-1.1.2.tgz#536cbc6549d06e8af11f76cb4fbd441ed2389e6e"
   integrity sha512-x0TGwgcOG21jOa8wV1PWXDpSXUAKa1WuhMSHPBQhXU5Pb+4DdMrxOw5HMAWztVLP8KhSG5Kl5BoAOVF0aW63wA==
@@ -5421,29 +5418,17 @@ mime-db@1.40.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
   integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
 
-mime-db@1.43.0:
-  version "1.43.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
-  integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
+mime-db@1.48.0:
+  version "1.48.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.48.0.tgz#e35b31045dd7eada3aaad537ed88a33afbef2d1d"
+  integrity sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==
 
-mime-db@1.47.0:
-  version "1.47.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.47.0.tgz#8cb313e59965d3c05cfbf898915a267af46a335c"
-  integrity sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==
-
-mime-types@^2.1.12:
-  version "2.1.30"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.30.tgz#6e7be8b4c479825f85ed6326695db73f9305d62d"
-  integrity sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==
+mime-types@^2.1.12, mime-types@~2.1.19:
+  version "2.1.31"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.31.tgz#a00d76b74317c61f9c2db2218b8e9f8e9c5c9e6b"
+  integrity sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==
   dependencies:
-    mime-db "1.47.0"
-
-mime-types@~2.1.19:
-  version "2.1.26"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
-  integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
-  dependencies:
-    mime-db "1.43.0"
+    mime-db "1.48.0"
 
 mime-types@~2.1.24:
   version "2.1.24"
@@ -5649,10 +5634,10 @@ nodemailer@^4.6.7:
   resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-4.7.0.tgz#4420e06abfffd77d0618f184ea49047db84f4ad8"
   integrity sha512-IludxDypFpYw4xpzKdMAozBSkzKHmNBvGanUREjJItgJ2NYcK/s8+PggVhj7c2yGFQykKsnnmv1+Aqo0ZfjHmw==
 
-nodemailer@^6.5.0:
-  version "6.6.1"
-  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.6.1.tgz#2a05fbf205b897d71bf43884167b5d4d3bd01b99"
-  integrity sha512-1xzFN3gqv+/qJ6YRyxBxfTYstLNt0FCtZaFRvf4Sg9wxNGWbwFmGXVpfSi6ThGK6aRxAo+KjHtYSW8NvCsNSAg==
+nodemailer@^6.6.1:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.6.2.tgz#e184c9ed5bee245a3e0bcabc7255866385757114"
+  integrity sha512-YSzu7TLbI+bsjCis/TZlAXBoM4y93HhlIgo0P5oiA2ua9Z4k+E2Fod//ybIzdJxOlXGRcHIh/WaeCBehvxZb/Q==
 
 normalize-package-data@^2.0.0, normalize-package-data@^2.3.2:
   version "2.5.0"
@@ -5881,11 +5866,6 @@ openapi-types@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/openapi-types/-/openapi-types-1.3.5.tgz#6718cfbc857fe6c6f1471f65b32bdebb9c10ce40"
   integrity sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg==
-
-opencollective-postinstall@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
-  integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -6491,7 +6471,7 @@ readable-stream@^2.3.5, readable-stream@^2.3.7:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.1.1, readable-stream@^3.4.0:
+readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -6653,33 +6633,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.86.0, request@latest:
-  version "2.88.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
-  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.8.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.6"
-    extend "~3.0.2"
-    forever-agent "~0.6.1"
-    form-data "~2.3.2"
-    har-validator "~5.1.0"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.19"
-    oauth-sign "~0.9.0"
-    performance-now "^2.1.0"
-    qs "~6.5.2"
-    safe-buffer "^5.1.2"
-    tough-cookie "~2.4.3"
-    tunnel-agent "^0.6.0"
-    uuid "^3.3.2"
-
-request@^2.87.0, request@^2.88.0:
+request@^2.86.0, request@^2.87.0, request@^2.88.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -6702,6 +6656,32 @@ request@^2.87.0, request@^2.88.0:
     qs "~6.5.2"
     safe-buffer "^5.1.2"
     tough-cookie "~2.5.0"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
+
+request@latest:
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
@@ -6841,12 +6821,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.2:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
-  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
-
-safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -7829,10 +7804,15 @@ unc-path-regex@^0.1.2:
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
-underscore@1.8.3, underscore@~1.8.3:
+underscore@1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
   integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
+
+underscore@^1.12.1:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
+  integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
 
 underscore@latest:
   version "1.9.1"
@@ -7955,9 +7935,9 @@ unset-value@^1.0.0:
     isobject "^3.0.0"
 
 uri-js@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
-  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
 
@@ -7996,12 +7976,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.0.0, uuid@~3.3.2:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
-  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
-
-uuid@^3.3.2:
+uuid@^3.0.0, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -8010,6 +7985,11 @@ uuid@^8.3.0:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@~3.3.2:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
+  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
#### List of Changes
- Added checks for user's services preferences during the message creation activity

#### Motivation and Context
We want to create messages only for users that allow to be reached, and manage LEGACY cases as usual looking into blockedInboxOrChannels.

#### How Has This Been Tested?
It has been tested by performing:
- yarn install (updated dependencies in yarn file due to merge conflicts)
- yarn build
- yarn lint
- yarn test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
