### PR TITLE
[#IP-300] Temporary ignore email service preference for not Legacy profiles

### DIFF
--- a/CreateNotificationActivity/handler.ts
+++ b/CreateNotificationActivity/handler.ts
@@ -29,6 +29,7 @@ import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/p
 import { ulidGenerator } from "@pagopa/io-functions-commons/dist/src/utils/strings";
 
 import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
+import { ServicesPreferencesModeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServicesPreferencesMode";
 import { SuccessfulStoreMessageContentActivityResult } from "../StoreMessageContentActivity/handler";
 
 /**
@@ -166,8 +167,13 @@ export const getCreateNotificationActivityHandler = (
 
   // first we check whether the user has blocked emails notifications for the
   // service that is sending the message
+  // Since we are not handling email service preferences for App version 1.29.0.1
+  // not Legacy profiles will use only profile level email preference.
   const isEmailBlockedForService =
-    blockedInboxOrChannels.indexOf(BlockedInboxOrChannelEnum.EMAIL) >= 0;
+    profile.servicePreferencesSettings.mode ===
+    ServicesPreferencesModeEnum.LEGACY
+      ? blockedInboxOrChannels.includes(BlockedInboxOrChannelEnum.EMAIL)
+      : false;
 
   // If the message is sent to the SANDBOX_FISCAL_CODE we consider it a test message
   // so we send the email notification to the email associated to the user owner

--- a/CreateNotificationActivity/handler.ts
+++ b/CreateNotificationActivity/handler.ts
@@ -171,9 +171,8 @@ export const getCreateNotificationActivityHandler = (
   // not Legacy profiles will use only profile level email preference.
   const isEmailBlockedForService =
     profile.servicePreferencesSettings.mode ===
-    ServicesPreferencesModeEnum.LEGACY
-      ? blockedInboxOrChannels.includes(BlockedInboxOrChannelEnum.EMAIL)
-      : false;
+      ServicesPreferencesModeEnum.LEGACY &&
+    blockedInboxOrChannels.includes(BlockedInboxOrChannelEnum.EMAIL);
 
   // If the message is sent to the SANDBOX_FISCAL_CODE we consider it a test message
   // so we send the email notification to the email associated to the user owner


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
User that using App version `1.29.0.1` can receive email if email is enabled in user profile.

#### List of Changes
<!--- Describe your changes in detail -->
`CreateNotificationActivity` evaluate service level email preference for profiles with preferences mode `AUTO` or `MANUAL` always enabled.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
User of App version `1.29.0.1` cannot change email service preferences. Only profile level email preferences should works.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
not tested

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
