### PR TITLE
[#IP-301] `GetSubscriptionFeed` Add service subscription check on profile unsubscription

### DIFF
--- a/GetSubscriptionsFeed/__tests__/handler.test.ts
+++ b/GetSubscriptionsFeed/__tests__/handler.test.ts
@@ -256,7 +256,7 @@ describe("GetSubscriptionsFeedHandler", () => {
     // service subscriptions
     queryEntities.mockImplementationOnce(
       queryEntitiesServiceSubscriptionMock(
-        [anHashedFiscalCode, anotherHashedFiscalCode],
+        [anHashedFiscalCode],
         "S"
       )
     );
@@ -283,7 +283,7 @@ describe("GetSubscriptionsFeedHandler", () => {
       expect(result.value).toEqual({
         dateUTC: yesterdayUTC,
         subscriptions: [],
-        unsubscriptions: [anHashedFiscalCode, anotherHashedFiscalCode]
+        unsubscriptions: [anotherHashedFiscalCode]
       });
     }
   });

--- a/GetSubscriptionsFeed/handler.ts
+++ b/GetSubscriptionsFeed/handler.ts
@@ -174,11 +174,14 @@ export function GetSubscriptionsFeedHandler(
 
     const unsubscriptions = new Array<FiscalCodeHash>();
 
-    profileUnsubscriptionsSet.forEach(pu =>
-      // add all users that deleted its own account
-      // eslint-disable-next-line functional/immutable-data
-      unsubscriptions.push(pu)
-    );
+    profileUnsubscriptionsSet.forEach(pu => {
+      if (!serviceSubscriptionsSet.has(pu)) {
+        // add all users that deleted its own account skipping those that
+        // subscribed to this service
+        // eslint-disable-next-line functional/immutable-data
+        unsubscriptions.push(pu);
+      }
+    });
 
     serviceUnsubscriptionsSet.forEach(su => {
       if (


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
User that enables a single service after switching to MANUAL mode, must be tracked on Subscription Feed because Profile Unsubscription is not related only to a Profile deletion.

#### List of Changes
<!--- Describe your changes in detail -->
- `GetSubscriptioFeed` evaluate service subscription while it reads a profile unsubscription
- Update test

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It solves a data inconsistence if User enables a single service after switching to MANUAL mode in the same day.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tested
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
