### PR TITLE
[#IP-303] Add tracing for message storing

### DIFF
--- a/StoreMessageContentActivity/__tests__/handler.test.ts
+++ b/StoreMessageContentActivity/__tests__/handler.test.ts
@@ -13,6 +13,7 @@ import { NonNegativeNumber } from "@pagopa/ts-commons/lib/numbers";
 import { fromLeft } from "fp-ts/lib/IOEither";
 import { none, some } from "fp-ts/lib/Option";
 import { taskEither } from "fp-ts/lib/TaskEither";
+import { initTelemetryClient } from "../../utils/appinsights";
 import {
   aCreatedMessageEventSenderMetadata,
   aDisabledServicePreference,
@@ -37,6 +38,10 @@ const mockContext = {
     warn: console.warn
   }
 } as any;
+
+const mockTelemetryClient = ({
+  trackEvent: jest.fn()
+} as unknown) as ReturnType<typeof initTelemetryClient>;
 
 const findLastVersionByModelIdMock = jest
   .fn()
@@ -122,6 +127,7 @@ const withBlockedEmail = (profile: RetrievedProfile, services = []) => ({
     {}
   )
 });
+
 describe("getStoreMessageContentActivityHandler", () => {
   beforeEach(() => {
     jest.resetAllMocks();
@@ -172,7 +178,8 @@ describe("getStoreMessageContentActivityHandler", () => {
           lBlobService: {} as any,
           lServicePreferencesModel,
           optOutEmailSwitchDate: aPastOptOutEmailSwitchDate,
-          isOptInEmailEnabled: false
+          isOptInEmailEnabled: false,
+          telemetryClient: mockTelemetryClient
         }
       );
 
@@ -232,7 +239,8 @@ describe("getStoreMessageContentActivityHandler", () => {
           lBlobService: {} as any,
           lServicePreferencesModel,
           optOutEmailSwitchDate: aPastOptOutEmailSwitchDate,
-          isOptInEmailEnabled: false
+          isOptInEmailEnabled: false,
+          telemetryClient: mockTelemetryClient
         }
       );
 
@@ -297,7 +305,8 @@ describe("getStoreMessageContentActivityHandler", () => {
           lBlobService: {} as any,
           lServicePreferencesModel,
           optOutEmailSwitchDate: aPastOptOutEmailSwitchDate,
-          isOptInEmailEnabled: false
+          isOptInEmailEnabled: false,
+          telemetryClient: mockTelemetryClient
         }
       );
 

--- a/StoreMessageContentActivity/handler.ts
+++ b/StoreMessageContentActivity/handler.ts
@@ -38,6 +38,7 @@ import { isBefore } from "date-fns";
 import { UTCISODateFromString } from "@pagopa/ts-commons/lib/dates";
 import { CosmosErrors } from "@pagopa/io-functions-commons/dist/src/utils/cosmosdb_model";
 import { initTelemetryClient } from "../utils/appinsights";
+import { toHash } from "../utils/crypto";
 
 export const SuccessfulStoreMessageContentActivityResult = t.interface({
   blockedInboxOrChannels: t.readonlyArray(BlockedInboxOrChannel),
@@ -390,6 +391,7 @@ export const getStoreMessageContentActivityHandler = ({
   telemetryClient.trackEvent({
     name: "api.messages.create.blockedstoremessage",
     properties: {
+      fiscalCode: toHash(profile.fiscalCode),
       isBlocked: String(isMessageStorageBlockedForService),
       messageId: createdMessageEvent.message.id,
       mode: profile.servicePreferencesSettings.mode,

--- a/StoreMessageContentActivity/index.ts
+++ b/StoreMessageContentActivity/index.ts
@@ -15,6 +15,7 @@ import {
 } from "@pagopa/io-functions-commons/dist/src/models/service_preference";
 import { cosmosdbInstance } from "../utils/cosmosdb";
 import { getConfigOrThrow } from "../utils/config";
+import { initTelemetryClient } from "../utils/appinsights";
 import { getStoreMessageContentActivityHandler } from "./handler";
 
 const config = getConfigOrThrow();
@@ -35,6 +36,10 @@ const servicePreferencesModel = new ServicesPreferencesModel(
   SERVICE_PREFERENCES_COLLECTION_NAME
 );
 
+const telemetryClient = initTelemetryClient(
+  config.APPINSIGHTS_INSTRUMENTATIONKEY
+);
+
 const activityFunctionHandler: AzureFunction = getStoreMessageContentActivityHandler(
   {
     isOptInEmailEnabled: config.FF_OPT_IN_EMAIL_ENABLED,
@@ -42,7 +47,8 @@ const activityFunctionHandler: AzureFunction = getStoreMessageContentActivityHan
     lMessageModel: messageModel,
     lProfileModel: profileModel,
     lServicePreferencesModel: servicePreferencesModel,
-    optOutEmailSwitchDate: config.OPT_OUT_EMAIL_SWITCH_DATE
+    optOutEmailSwitchDate: config.OPT_OUT_EMAIL_SWITCH_DATE,
+    telemetryClient
   }
 );
 

--- a/utils/__tests__/profile.test.ts
+++ b/utils/__tests__/profile.test.ts
@@ -124,7 +124,7 @@ const withBlacklist = (profile: RetrievedProfile, services = []) => ({
   blockedInboxOrChannels: services.reduce(
     (obj, serviceId) => ({
       ...obj,
-      [serviceId]: BlockedInboxOrChannelEnum.INBOX
+      [serviceId]: [BlockedInboxOrChannelEnum.INBOX]
     }),
     {}
   )

--- a/utils/crypto.ts
+++ b/utils/crypto.ts
@@ -1,0 +1,14 @@
+/**
+ * Common usages of crypto features
+ */
+
+import * as crypto from "crypto";
+
+export const toHash = (s: string): string =>
+  crypto
+    .createHash("sha256")
+    .update(s)
+    .digest("hex");
+
+export const randomBytes = (size: number): string =>
+  crypto.randomBytes(size).toString("hex");


### PR DESCRIPTION
Add the `api.messages.create.blockedstoremessage` custom event so that we can monitor:
* how many messages are accepted/rejected due to Citizen preferences
* how many Citizens are receiving messages and are in `LEGACY` mode
* how many messages are rejected, grouped by preference mode

