### PR TITLE
[#ENTE-130] Messages to SANDBOX account don't send emails to services user

### DIFF
--- a/CreateNotificationActivity/handler.ts
+++ b/CreateNotificationActivity/handler.ts
@@ -156,15 +156,6 @@ export const getCreateNotificationActivityHandler = (
   // Decide whether to send an email notification
   //
 
-  // whether email notifications are enabled in this user profile - this is
-  // true by default, it's false only for users that have isEmailEnabled = false
-  // in their profile.
-  const isEmailEnabledInProfile = profile.isEmailEnabled !== false;
-
-  // Check if the email in the user profile is validated.
-  // we assume it's true when not defined in user's profile.
-  const isEmailValidatedInProfile = profile.isEmailValidated !== false;
-
   // first we check whether the user has blocked emails notifications for the
   // service that is sending the message
   // Since we are not handling email service preferences for App version 1.29.0.1
@@ -193,6 +184,21 @@ export const getCreateNotificationActivityHandler = (
   const isEmailDisabledForService = lEmailNotificationServiceBlackList.includes(
     createdMessageEvent.message.senderServiceId
   );
+
+  // whether email notifications are enabled in this user profile - this is
+  // true by default, it's false only for users that have isEmailEnabled = false
+  // in their profile.
+  // Email is enabled if the message is sent to the SANDBOX_FISCAL_CODE
+  const isEmailEnabledInProfile =
+    newMessageWithoutContent.fiscalCode === lSandboxFiscalCode ||
+    profile.isEmailEnabled !== false;
+
+  // Check if the email in the user profile is validated.
+  // we assume it's true when not defined in user's profile.
+  // Email is validated if the message is sent to the SANDBOX_FISCAL_CODE
+  const isEmailValidatedInProfile =
+    newMessageWithoutContent.fiscalCode === lSandboxFiscalCode ||
+    profile.isEmailValidated !== false;
 
   // finally we decide whether we should send the email notification or not -
   // we send an email notification when all the following conditions are met:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
When the message is sent to the SANDBOX_FISCAL_CODE the email address (overridden with the sender email address) is considered enabled and validated.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A developer that was testing the `CreateMessage` API doesn't receive the email for validating his implementation.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

not tested

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

