### PR TITLE
[#IC-206] Enable multi-provider for Legal Message

### DIFF
--- a/CreateLegalMessage/__tests__/handler.test.ts
+++ b/CreateLegalMessage/__tests__/handler.test.ts
@@ -184,7 +184,7 @@ describe("CreateLegalMessageHandler", () => {
       dummyPecServerUserAttribute,
       reqMock,
       VALID_LEGAL_MAIL,
-      undefined as any
+      reqMock.body
     );
 
     expect(reqMock.body.content.legal_data.pec_server_service_id).toEqual(
@@ -216,7 +216,7 @@ describe("CreateLegalMessageHandler", () => {
       dummyPecServerUserAttribute,
       reqMock,
       VALID_LEGAL_MAIL,
-      undefined as any
+      reqMock.body
     );
 
     expect(adminClientMock.getImpersonatedService).toHaveBeenCalledTimes(1);
@@ -246,7 +246,7 @@ describe("CreateLegalMessageHandler", () => {
       dummyPecServerUserAttribute,
       reqMock,
       VALID_LEGAL_MAIL,
-      undefined as any
+      reqMock.body
     );
 
     expect(adminClientMock.getImpersonatedService).not.toHaveBeenCalled();
@@ -276,7 +276,7 @@ describe("CreateLegalMessageHandler", () => {
       dummyPecServerUserAttribute,
       reqMock,
       VALID_LEGAL_MAIL,
-      undefined as any
+      reqMock.body
     );
 
     expect(adminClientMock.getImpersonatedService).not.toHaveBeenCalled();
@@ -342,7 +342,7 @@ describe("CreateLegalMessageHandler", () => {
         dummyPecServerUserAttribute,
         reqMock,
         VALID_LEGAL_MAIL,
-        undefined as any
+        reqMock.body
       );
 
       expect(adminClientMock.getImpersonatedService).toHaveBeenCalledTimes(1);
@@ -399,7 +399,7 @@ describe("CreateLegalMessageHandler", () => {
         dummyPecServerUserAttribute,
         reqMock,
         VALID_LEGAL_MAIL,
-        undefined as any
+        reqMock.body
       );
 
       expect(adminClientMock.getImpersonatedService).toHaveBeenCalledTimes(1);

--- a/CreateLegalMessage/handler.ts
+++ b/CreateLegalMessage/handler.ts
@@ -108,7 +108,7 @@ export function CreateLegalMessageHandler(
     context,
     _auth,
     _attrs,
-    _ip,
+    ip,
     rawRequest,
     legalmail,
     _payload
@@ -140,6 +140,20 @@ export function CreateLegalMessageHandler(
         rawRequest.headers = {
           ...rawRequest.headers,
           ...replaceHeaders
+        };
+      }),
+      // decorate message legal_data with the pec-server service_id
+      TE.map(() => {
+        // eslint-disable-next-line functional/immutable-data
+        rawRequest.body = {
+          ...rawRequest.body,
+          content: {
+            ...rawRequest.body?.content,
+            legal_data: {
+              ...rawRequest.body?.content?.legal_data,
+              pec_server_service_id: ip.service.serviceId
+            }
+          }
         };
       }),
       TE.chain(() =>

--- a/CreateLegalMessage/handler.ts
+++ b/CreateLegalMessage/handler.ts
@@ -107,11 +107,11 @@ export function CreateLegalMessageHandler(
   return (
     context,
     _auth,
-    _attrs,
-    ip,
+    _ip,
+    attrs,
     rawRequest,
     legalmail,
-    _payload
+    payload
     // eslint-disable-next-line max-params
   ): ReturnType<ICreateLegalMessageHandler> =>
     pipe(
@@ -144,16 +144,20 @@ export function CreateLegalMessageHandler(
       }),
       // decorate message legal_data with the pec-server service_id
       TE.map(() => {
+        const decoratedPayload = {
+          ...payload,
+          content: {
+            ...payload.content,
+            legal_data: {
+              ...payload.content.legal_data,
+              pec_server_service_id: attrs.service.serviceId
+            }
+          }
+        };
         // eslint-disable-next-line functional/immutable-data
         rawRequest.body = {
           ...rawRequest.body,
-          content: {
-            ...rawRequest.body?.content,
-            legal_data: {
-              ...rawRequest.body?.content?.legal_data,
-              pec_server_service_id: ip.service.serviceId
-            }
-          }
+          ...decoratedPayload
         };
       }),
       TE.chain(() =>

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -1456,6 +1456,8 @@ definitions:
       original_message_url:
         type: string
         minLength: 1
+      pec_server_service_id:
+        $ref: '#/definitions/ServiceId'
     required:
       - sender_mail_from
       - has_attachment

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@azure/cosmos": "^3.11.5",
     "@pagopa/express-azure-functions": "^2.0.0",
-    "@pagopa/io-functions-commons": "^22.6.0",
+    "@pagopa/io-functions-commons": "^22.7.0",
     "@pagopa/ts-commons": "^10.2.0",
     "applicationinsights": "^1.7.4",
     "azure-storage": "^2.10.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -738,10 +738,10 @@
   resolved "https://registry.yarnpkg.com/@pagopa/express-azure-functions/-/express-azure-functions-2.0.0.tgz#eb52a0b997d931c1509372e2a9bea22a8ca85c17"
   integrity sha512-IFZqtk0e2sfkMZIxYqPORzxcKRkbIrVJesR6eMLNwzh1rA4bl2uh9ZHk1m55LNq4ZmaxREDu+1JcGlIaZQgKNQ==
 
-"@pagopa/io-functions-commons@^22.6.0":
-  version "22.6.0"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-22.6.0.tgz#fd9a9ff8fbe7314818cb69056cbec83f5407a671"
-  integrity sha512-Q3kQ1kg/SY+bOPzuujRX8xUE3ZJOhxOXHbcSOlyRISfABmPJLXSpWFkupN7rK/T2HkFY8NVyw35vZDIuVtBJHw==
+"@pagopa/io-functions-commons@^22.7.0":
+  version "22.7.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-22.7.0.tgz#83de411c059788f0849a0702440c377c0e3b4d48"
+  integrity sha512-g61+FqrzM6WTEgoZWnWe4vHANdbMleHvlAoS3YiI8Rl0apP9C3nWu1v9XXjloqM2TX01ewnVPEd7F2ozKBAO5Q==
   dependencies:
     "@azure/cosmos" "^3.11.5"
     "@pagopa/ts-commons" "^10.0.1"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The Legal Message could be sent to IO by different PEC-SERVER. IO must store the PEC-SERVER sender ID in order to properly manage message nerichment.

#### List of Changes
<!--- Describe your changes in detail -->
add pec-server service enrichment to legal_data in the CreateLegalMessage function

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Properly store the pec-server id of the legal message sender without relying on external input

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
