### PR TITLE
[#IOCIT-25] Fix for channelToBlockedInboxOrChannelEnum after accessReadMessageStatus addition to ServicePreference

### DIFF
--- a/ProcessMessage/handler.ts
+++ b/ProcessMessage/handler.ts
@@ -103,7 +103,10 @@ type ServicePreferencesValues = Omit<
 >;
 
 const channelToBlockedInboxOrChannelEnum: {
-  readonly [key in keyof ServicePreferencesValues]: BlockedInboxOrChannelEnum;
+  readonly [key in keyof Omit<
+    ServicePreferencesValues,
+    "accessReadMessageStatus"
+  >]: BlockedInboxOrChannelEnum;
 } = {
   isEmailEnabled: BlockedInboxOrChannelEnum.EMAIL,
   isInboxEnabled: BlockedInboxOrChannelEnum.INBOX,

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@azure/cosmos": "^3.15.1",
     "@pagopa/express-azure-functions": "^2.0.0",
-    "@pagopa/io-functions-commons": "^24.5.1",
+    "@pagopa/io-functions-commons": "^25.5.0",
     "@pagopa/ts-commons": "^10.2.0",
     "applicationinsights": "^1.7.4",
     "azure-storage": "^2.10.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -743,13 +743,13 @@
   resolved "https://registry.yarnpkg.com/@pagopa/express-azure-functions/-/express-azure-functions-2.0.0.tgz#eb52a0b997d931c1509372e2a9bea22a8ca85c17"
   integrity sha512-IFZqtk0e2sfkMZIxYqPORzxcKRkbIrVJesR6eMLNwzh1rA4bl2uh9ZHk1m55LNq4ZmaxREDu+1JcGlIaZQgKNQ==
 
-"@pagopa/io-functions-commons@^24.5.1":
-  version "24.5.1"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-24.5.1.tgz#5d67a21917d1dc4c23d458770b524edfd81b259a"
-  integrity sha512-wugvJRkCHg4PMdim84YIiZjdJLuCOrvS8/vv4dUbC37YViMqwGfW+UEAoYSKvKiwYs7cwQRseJ42i5JM5desDg==
+"@pagopa/io-functions-commons@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-25.5.0.tgz#8351baa0c52c7bb2fd475b3c1201677957aac677"
+  integrity sha512-BZriw5LJlIKBbXORCMuuOWXLF4kENDKqMwfYzpJGuUMWfAzEAggd076C0V+eaILpdq5U2JmyfyvXFyAI5uUiZg==
   dependencies:
     "@azure/cosmos" "^3.15.1"
-    "@pagopa/ts-commons" "^10.3.0"
+    "@pagopa/ts-commons" "^10.5.0"
     applicationinsights "^1.8.10"
     azure-storage "^2.10.5"
     cidr-matcher "^2.1.1"
@@ -784,7 +784,7 @@
     write-yaml-file "^4.1.3"
     yargs "^15.0.1"
 
-"@pagopa/ts-commons@^10.0.0", "@pagopa/ts-commons@^10.2.0", "@pagopa/ts-commons@^10.3.0":
+"@pagopa/ts-commons@^10.0.0", "@pagopa/ts-commons@^10.2.0", "@pagopa/ts-commons@^10.5.0":
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/@pagopa/ts-commons/-/ts-commons-10.2.0.tgz#ac4c65f2d24f8d2c427ab5e7fcb88732976800ef"
   integrity sha512-Uq+rmMR1+QvDZUUZeka/KaPVJaUeL3UHcPjVmHncSjAFQczL2mcAC9AadtY3cHiI+eQ0Mw2exjj4HOaABC2KAA==


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Omitted `accessReadMessageStatus` from ServicePreference to define channelToBlockedInboxOrChannelEnum with keyOf.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The new preference is not correlated with blocked inbox or channels.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
yarn build 
yarn test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
