### PR TITLE
[#IOPSC-81] Trace ApiKey existence on Service creation

### DIFF
--- a/CreateService/handler.ts
+++ b/CreateService/handler.ts
@@ -193,6 +193,8 @@ export function CreateServiceHandler(
         telemetryClient.trackEvent({
           name: "api.services.create",
           properties: {
+            has_primary_key: Boolean(subscription.primary_key),
+            has_secondary_key: Boolean(subscription.secondary_key),
             isVisible: String(service.is_visible),
             requesterUserEmail: userAttributes.email,
             subscriptionId


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
* add `has_primary_key` and `has_secondary_key` attribute on `api.services.create` tracing event
`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We have feedback of Services created correctly but the payload does not contain the ApiKey. This PR introduces a traces so that we can have evidence of the bug

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
