### PR TITLE
[IOCIT-195] Use messageStatusUpdarter to set the ttl

### DIFF
--- a/OnFailedProcessMessage/__tests__/handler.test.ts
+++ b/OnFailedProcessMessage/__tests__/handler.test.ts
@@ -45,19 +45,19 @@ const aCreatedMessageEvent: CreatedMessageEvent = {
 beforeEach(() => {
   jest.clearAllMocks();
   // Mock getMessageStatusUpdater
-  getMessageStatusUpdaterMock.mockImplementation((
-    _messageStatusModel: MS.MessageStatusModel,
-    messageId: NonEmptyString,
-    fiscalCode: FiscalCode
-    // status type does not match anymore for some reason
-  ) => (status: any) =>
-    TE.right({
-      ...aRetrievedMessageStatus,
-      id: messageId,
-      messageId,
-      ...status,
-      fiscalCode
-    })
+  getMessageStatusUpdaterMock.mockImplementation(
+    (
+      _messageStatusModel: MS.MessageStatusModel,
+      messageId: NonEmptyString,
+      fiscalCode: FiscalCode
+    ) => (status: Parameters<MS.MessageStatusUpdater>[0]) =>
+      TE.right({
+        ...aRetrievedMessageStatus,
+        id: messageId,
+        messageId,
+        ...status,
+        fiscalCode
+      })
   );
   getQueryIteratorMock.mockImplementation(() => {
     const asyncIterable = {

--- a/OnFailedProcessMessage/__tests__/handler.test.ts
+++ b/OnFailedProcessMessage/__tests__/handler.test.ts
@@ -45,19 +45,19 @@ const aCreatedMessageEvent: CreatedMessageEvent = {
 beforeEach(() => {
   jest.clearAllMocks();
   // Mock getMessageStatusUpdater
-  getMessageStatusUpdaterMock.mockImplementation(
-    (
-      _messageStatusModel: MS.MessageStatusModel,
-      messageId: NonEmptyString,
-      fiscalCode: FiscalCode
-    ) => (status: Parameters<MS.MessageStatusUpdater>[0]) =>
-      TE.right({
-        ...aRetrievedMessageStatus,
-        id: messageId,
-        messageId,
-        ...status,
-        fiscalCode
-      })
+  getMessageStatusUpdaterMock.mockImplementation((
+    _messageStatusModel: MS.MessageStatusModel,
+    messageId: NonEmptyString,
+    fiscalCode: FiscalCode
+    // status type does not match anymore for some reason
+  ) => (status: any) =>
+    TE.right({
+      ...aRetrievedMessageStatus,
+      id: messageId,
+      messageId,
+      ...status,
+      fiscalCode
+    })
   );
   getQueryIteratorMock.mockImplementation(() => {
     const asyncIterable = {

--- a/ProcessMessage/__tests__/handler.test.ts
+++ b/ProcessMessage/__tests__/handler.test.ts
@@ -882,9 +882,7 @@ describe("getprocessMessageHandler", () => {
 
     await expect(
       processMessageHandler(context, JSON.stringify(aCreatedMessageEvent))
-    ).rejects.toThrow(
-      "Error while updating message status to REJECTED|PROFILE_NOT_FOUND"
-    );
+    ).rejects.toThrow("Error while setting the ttl");
   });
 
   it("it should throw an error if the set of ttl on message status fails", async () => {
@@ -917,8 +915,6 @@ describe("getprocessMessageHandler", () => {
 
     await expect(
       processMessageHandler(context, JSON.stringify(aCreatedMessageEvent))
-    ).rejects.toThrow(
-      "Error while updating message status to REJECTED|PROFILE_NOT_FOUND"
-    );
+    ).rejects.toThrow("Error while setting the ttl");
   });
 });

--- a/ProcessMessage/__tests__/handler.test.ts
+++ b/ProcessMessage/__tests__/handler.test.ts
@@ -278,8 +278,7 @@ beforeEach(() => {
       messageId: NonEmptyString,
       fiscalCode: FiscalCode
     ) =>
-      // status type does not match anymore for some reason
-      jest.fn((status: any) =>
+      jest.fn((status: Parameters<MS.MessageStatusUpdater>[0]) =>
         TE.right({
           _etag: "a",
           _rid: "a",

--- a/ProcessMessage/__tests__/handler.test.ts
+++ b/ProcessMessage/__tests__/handler.test.ts
@@ -64,6 +64,7 @@ import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitio
 import { RejectedMessageStatusValueEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/RejectedMessageStatusValue";
 import { RejectionReasonEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/RejectionReason";
 import { CosmosErrors } from "@pagopa/io-functions-commons/dist/src/utils/cosmosdb_model";
+import { Ttl } from "@pagopa/io-functions-commons/dist/src/utils/cosmosdb_model_ttl";
 
 const TTL_FOR_USER_NOT_FOUND = 94670856 as NonNegativeInteger;
 const isUserEligibleForNewFeature = (_: FiscalCode) => true;
@@ -277,7 +278,8 @@ beforeEach(() => {
       messageId: NonEmptyString,
       fiscalCode: FiscalCode
     ) =>
-      jest.fn((status: Parameters<MS.MessageStatusUpdater>[0]) =>
+      // status type does not match anymore for some reason
+      jest.fn((status: any) =>
         TE.right({
           _etag: "a",
           _rid: "a",
@@ -824,11 +826,17 @@ describe("getprocessMessageHandler", () => {
     const messageStatusUpdaterMock = getMessageStatusUpdaterMock.mock.results[0]
       .value as jest.Mock;
     expect(messageStatusUpdaterMock).toHaveBeenCalledTimes(1);
+    expect(messageStatusUpdaterMock).toHaveBeenCalledWith({
+      rejection_reason: "USER_NOT_FOUND",
+      status: "REJECTED",
+      ttl: 94670856
+    });
     const messageStatusUpdaterParam = messageStatusUpdaterMock.mock.calls[0][0];
 
     expect(messageStatusUpdaterParam).toEqual({
       status: RejectedMessageStatusValueEnum.REJECTED,
-      rejection_reason: RejectionReasonEnum.USER_NOT_FOUND
+      rejection_reason: RejectionReasonEnum.USER_NOT_FOUND,
+      ttl: 94670856
     });
 
     // check if models are being used only when expected
@@ -875,7 +883,9 @@ describe("getprocessMessageHandler", () => {
 
     await expect(
       processMessageHandler(context, JSON.stringify(aCreatedMessageEvent))
-    ).rejects.toThrow("Error while setting ttl");
+    ).rejects.toThrow(
+      "Error while updating message status to REJECTED|PROFILE_NOT_FOUND"
+    );
   });
 
   it("it should throw an error if the set of ttl on message status fails", async () => {
@@ -908,6 +918,8 @@ describe("getprocessMessageHandler", () => {
 
     await expect(
       processMessageHandler(context, JSON.stringify(aCreatedMessageEvent))
-    ).rejects.toThrow("Error while setting ttl");
+    ).rejects.toThrow(
+      "Error while updating message status to REJECTED|PROFILE_NOT_FOUND"
+    );
   });
 });

--- a/ProcessMessage/handler.ts
+++ b/ProcessMessage/handler.ts
@@ -506,7 +506,11 @@ export const getProcessMessageHandler = ({
                   )
                 ),
                 TE.getOrElse(e => {
-                  context.log.error(`${logPrefix}|ERROR=${JSON.stringify(e)}`);
+                  context.log.error(
+                    `${logPrefix}|PROFILE_NOT_FOUND|UPSERT_STATUS=REJECTED|ERROR=${JSON.stringify(
+                      e
+                    )}`
+                  );
                   throw new Error("Error while setting the ttl");
                 })
               )();

--- a/ProcessMessage/handler.ts
+++ b/ProcessMessage/handler.ts
@@ -440,6 +440,7 @@ export const getProcessMessageHandler = ({
                   telemetryClient.trackEvent({
                     name: "api.messages.create.create-status-fail",
                     properties: {
+                      errorAsJson: JSON.stringify(err),
                       errorKind: "messageStatusUpdater failed",
                       fiscalCode: toHash(newMessageWithoutContent.fiscalCode),
                       messageId: newMessageWithoutContent.id,

--- a/ProcessMessage/handler.ts
+++ b/ProcessMessage/handler.ts
@@ -462,22 +462,6 @@ export const getProcessMessageHandler = ({
                     TTL_FOR_USER_NOT_FOUND
                   )
                 ),
-                TE.map(updatedCount => {
-                  if (updatedCount === 0) {
-                    telemetryClient.trackEvent({
-                      name: "api.messages.create.update-status-ttl-count-zero",
-                      properties: {
-                        errorKind:
-                          "updateTTLForAllVersions updated zero documents",
-                        fiscalCode: toHash(newMessageWithoutContent.fiscalCode),
-                        messageId: newMessageWithoutContent.id,
-                        senderId: newMessageWithoutContent.senderServiceId
-                      },
-                      tagOverrides: { samplingEnabled: "false" }
-                    });
-                  }
-                  return updatedCount;
-                }),
                 TE.mapLeft((error: CosmosErrors) => {
                   telemetryClient.trackEvent({
                     name: "api.messages.create.fail-status-ttl-set",

--- a/ProcessMessage/handler.ts
+++ b/ProcessMessage/handler.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-lines-per-function */
 
 import { Context } from "@azure/functions";
-import * as t from "io-ts";
 import { BlockedInboxOrChannelEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
 import { EUCovidCert } from "@pagopa/io-functions-commons/dist/generated/definitions/EUCovidCert";
 import { FiscalCode } from "@pagopa/io-functions-commons/dist/generated/definitions/FiscalCode";
@@ -352,12 +351,8 @@ const createMessageOrThrow = async (
   }
 };
 
-// ttl can only be a positive integer or -1
-const ttlType = t.union([NonNegativeInteger, t.literal(-1)]);
-type TtlType = t.TypeOf<typeof ttlType>;
-
 export interface IProcessMessageHandlerInput {
-  readonly TTL_FOR_USER_NOT_FOUND: TtlType;
+  readonly TTL_FOR_USER_NOT_FOUND: Ttl;
   readonly isUserEligibleForNewFeature: (fc: FiscalCode) => boolean;
   readonly lActivation: ActivationModel;
   readonly lProfileModel: ProfileModel;
@@ -439,7 +434,7 @@ export const getProcessMessageHandler = ({
                 messageStatusUpdater({
                   rejection_reason: RejectionReasonEnum.USER_NOT_FOUND,
                   status: RejectedMessageStatusValueEnum.REJECTED,
-                  ttl: TTL_FOR_USER_NOT_FOUND as Ttl
+                  ttl: TTL_FOR_USER_NOT_FOUND
                 }),
                 TE.chain(() =>
                   lMessageStatusModel.updateTTLForAllVersions(

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@azure/cosmos": "^3.17.1",
     "@pagopa/express-azure-functions": "^2.0.0",
-    "@pagopa/io-functions-commons": "^26.2.0",
+    "@pagopa/io-functions-commons": "^26.2.1",
     "@pagopa/ts-commons": "^10.10.0",
     "applicationinsights": "^1.7.4",
     "azure-storage": "^2.10.4",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@azure/cosmos": "^3.17.1",
     "@pagopa/express-azure-functions": "^2.0.0",
-    "@pagopa/io-functions-commons": "^26.1.1",
+    "@pagopa/io-functions-commons": "^26.2.0",
     "@pagopa/ts-commons": "^10.10.0",
     "applicationinsights": "^1.7.4",
     "azure-storage": "^2.10.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -751,10 +751,10 @@
   resolved "https://registry.yarnpkg.com/@pagopa/express-azure-functions/-/express-azure-functions-2.0.0.tgz#eb52a0b997d931c1509372e2a9bea22a8ca85c17"
   integrity sha512-IFZqtk0e2sfkMZIxYqPORzxcKRkbIrVJesR6eMLNwzh1rA4bl2uh9ZHk1m55LNq4ZmaxREDu+1JcGlIaZQgKNQ==
 
-"@pagopa/io-functions-commons@^26.2.0":
-  version "26.2.0"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-26.2.0.tgz#f828075f78ee57b9ca73956cb35a77652835df48"
-  integrity sha512-6GMivFVaY343bA8Otx+JsCkUfK18xvF9YA4UxFNf3uxkHwvtGprZCKdIRBa4Y+pKdFZMZrcXIXHv/GcuckBQSw==
+"@pagopa/io-functions-commons@^26.2.1":
+  version "26.2.1"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-26.2.1.tgz#82975563db316b12aa539a163dff7a14d8773f3e"
+  integrity sha512-k3K8Fur7gMOG1+d9ckVOjem8ARRSV8FXII2uWH96SN0gcDJuiQYhwlAUYBJhlPDm/s0TlC9r2RdZRXaiUaZFTQ==
   dependencies:
     "@azure/cosmos" "^3.17.1"
     "@pagopa/ts-commons" "^10.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -751,10 +751,10 @@
   resolved "https://registry.yarnpkg.com/@pagopa/express-azure-functions/-/express-azure-functions-2.0.0.tgz#eb52a0b997d931c1509372e2a9bea22a8ca85c17"
   integrity sha512-IFZqtk0e2sfkMZIxYqPORzxcKRkbIrVJesR6eMLNwzh1rA4bl2uh9ZHk1m55LNq4ZmaxREDu+1JcGlIaZQgKNQ==
 
-"@pagopa/io-functions-commons@^26.1.1":
-  version "26.1.1"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-26.1.1.tgz#3c29868dcb146eeb8f5ba0bee6d8f6b83dc968e5"
-  integrity sha512-QWR9NP+fF4t0sSsQwUXqD4H4areW6Y65tuJKvC4J7AjmmgpF4p67oP/YorbOa2AR9dP9ct4PV4viXTaQCwBKfw==
+"@pagopa/io-functions-commons@^26.2.0":
+  version "26.2.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-26.2.0.tgz#f828075f78ee57b9ca73956cb35a77652835df48"
+  integrity sha512-6GMivFVaY343bA8Otx+JsCkUfK18xvF9YA4UxFNf3uxkHwvtGprZCKdIRBa4Y+pKdFZMZrcXIXHv/GcuckBQSw==
   dependencies:
     "@azure/cosmos" "^3.17.1"
     "@pagopa/ts-commons" "^10.9.0"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
* Update `@pagopa/io-functions-commons`;
* Set the `ttl` during the upsert when the user does not exist;

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to set the ttl directly when creating the entry of the message status in order to solve an issue with cosmos.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
