### PR TITLE
Refactor sandbox fiscal code to be a string or an array of CF

### DIFF
--- a/CreateService/handler.ts
+++ b/CreateService/handler.ts
@@ -124,7 +124,7 @@ const createServiceTask = (
   apiClient: APIClient,
   servicePayload: ServicePayload,
   subscriptionId: NonEmptyString,
-  sandboxFiscalCode: FiscalCode,
+  authorizedRecipients: ReadonlyArray<FiscalCode>,
   adb2cTokenName: NonEmptyString
   // eslint-disable-next-line max-params
 ): TaskEither<ErrorResponses, Service> =>
@@ -134,7 +134,7 @@ const createServiceTask = (
       apiClient.createService({
         body: {
           ...servicePayload,
-          authorized_recipients: [sandboxFiscalCode],
+          authorized_recipients: authorizedRecipients,
           service_id: subscriptionId,
           service_metadata: {
             ...servicePayload.service_metadata,
@@ -156,7 +156,7 @@ export function CreateServiceHandler(
   apiClient: APIClient,
   generateObjectId: ObjectIdGenerator,
   productName: NonEmptyString,
-  sandboxFiscalCode: NonEmptyString
+  authorizedRecipients: NonEmptyString | ReadonlyArray<FiscalCode>
 ): ICreateServiceHandler {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   return (context, __, ___, userAttributes, servicePayload) => {
@@ -185,7 +185,10 @@ export function CreateServiceHandler(
           apiClient,
           servicePayload,
           subscriptionId,
-          (sandboxFiscalCode as unknown) as FiscalCode,
+          // (sandboxFiscalCode as unknown) as FiscalCode,
+          Array.isArray(authorizedRecipients)
+            ? authorizedRecipients
+            : [authorizedRecipients],
           user.token_name
         )
       ),


### PR DESCRIPTION
This PR add the ability of define a set of custom fiscal code when a service is created.

#### List of Changes
Handler now can accept a string or an array of fiscal code.

#### Motivation and Context
When a service is created with the CreateService API we want to have a custom set of valid fiscal code belongs to the service.

#### How Has This Been Tested?
A Jest test is included.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

