### PR TITLE
[IOPAE-218] remove `default_addresses`

### DIFF
--- a/CreateMessage/__tests__/handler.test.ts
+++ b/CreateMessage/__tests__/handler.test.ts
@@ -16,7 +16,6 @@ import * as TE from "fp-ts/lib/TaskEither";
 import * as O from "fp-ts/lib/Option";
 
 import {
-  canDefaultAddresses,
   canPaymentAmount,
   canWriteMessage,
   createMessageDocument,
@@ -31,7 +30,6 @@ import {
   fiscalCodeSetArb,
   maxAmountArb,
   messageTimeToLiveArb,
-  newMessageWithDefaultEmailArb,
   newMessageWithPaymentDataArb
 } from "../../utils/__tests__/arbitraries";
 import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
@@ -138,17 +136,6 @@ describe("canWriteMessage", () => {
           expect(E.isRight(response)).toBeTruthy();
         }
       )
-    );
-  });
-});
-
-describe("canDefaultAddresses", () => {
-  it("should always respond with ResponseErrorForbiddenNotAuthorizedForDefaultAddresses when default addresses are provided", () => {
-    fc.assert(
-      fc.property(newMessageWithDefaultEmailArb, m => {
-        const response = canDefaultAddresses(m);
-        expect(E.isLeft(response)).toBeTruthy();
-      })
     );
   });
 });

--- a/utils/__tests__/arbitraries.ts
+++ b/utils/__tests__/arbitraries.ts
@@ -106,15 +106,6 @@ export const newMessageArb = fc
   )
   .filter(_ => _ !== undefined);
 
-export const newMessageWithDefaultEmailArb = fc
-  .tuple(newMessageArb, fc.emailAddress())
-  .map(([m, email]) => ({
-    ...m,
-    default_addresses: {
-      email: email as EmailString
-    }
-  }));
-
 export const messageTimeToLiveArb = fc
   .integer(3600, 604800)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about these changes' context. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as if you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Removed the `default_addresses` field from user input when creating a message

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The field has been deprecated long ago and it's no longer used by our users. We can safely remove it as it's an operational value that does not affect the stored message.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes from a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
