### PR TITLE
[#IOCOM-604] require secure channels

### DIFF
--- a/CreateMessage/__tests__/handler.test.ts
+++ b/CreateMessage/__tests__/handler.test.ts
@@ -44,7 +44,6 @@ import {
 import { initAppInsights } from "@pagopa/ts-commons/lib/appinsights";
 import { ApiNewMessageWithDefaults } from "../types";
 import { Context } from "@azure/functions";
-import { ServiceMetadata } from "@pagopa/io-functions-admin-sdk/ServiceMetadata";
 
 const createContext = (): Context =>
   (({

--- a/CreateMessage/handler.ts
+++ b/CreateMessage/handler.ts
@@ -377,7 +377,10 @@ export function CreateMessageHandler(
                 departmentName: service.departmentName,
                 organizationFiscalCode: service.organizationFiscalCode,
                 organizationName: service.organizationName,
-                requireSecureChannels: service.requireSecureChannels,
+                requireSecureChannels:
+                  messagePayload.content.require_secure_channels !== undefined
+                    ? messagePayload.content.require_secure_channels
+                    : service.requireSecureChannels,
                 serviceCategory: pipe(
                   O.fromNullable(service.serviceMetadata?.category),
                   O.getOrElse(() => StandardServiceCategoryEnum.STANDARD)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
-[new require secure channels flag logic](https://github.com/pagopa/io-functions-services/commit/e33ffd26439c5357fc794a29aebd5e4ff1544406)
- [Fix unit test and add another test case](https://github.com/pagopa/io-functions-services/commit/5412e8008c3064c0607d61b4a88581ebbb917874)
- [Remove unused import](https://github.com/pagopa/io-functions-services/commit/d3d6ea5a9004c4c9057ecec6e69deb10b611c04d)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- new logic to manage the require_secure_channels flag when is passed inside the message

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
