### PR TITLE
[#IOCOM-705] Return 403 if attachments are provided with a non premium message

### DIFF
--- a/CreateMessage/__tests__/handler.test.ts
+++ b/CreateMessage/__tests__/handler.test.ts
@@ -416,7 +416,7 @@ describe("CreateMessageHandler", () => {
     );
   });
 
-  it("should return 403 error if the flag has_remote_content is true but the message is not advanced", async () => {
+  it("should return 403 error if the flag has_attachments is true but the message is not advanced", async () => {
     const createMessageHandler = CreateMessageHandler(
       mockTelemetryClient,
       mockMessageModel,
@@ -449,7 +449,7 @@ describe("CreateMessageHandler", () => {
     );
   });
 
-  it("should return 403 error if the flag has_remote_content is true but the feature_level_type is not provided", async () => {
+  it("should return 403 error if the flag has_attachments true but the feature_level_type is not provided", async () => {
     const createMessageHandler = CreateMessageHandler(
       mockTelemetryClient,
       mockMessageModel,

--- a/CreateMessage/__tests__/handler.test.ts
+++ b/CreateMessage/__tests__/handler.test.ts
@@ -448,4 +448,36 @@ describe("CreateMessageHandler", () => {
       "Attachments call forbidden: You are not allowed to send messages with attachmens with STANDARD messages, please use ADVANCED"
     );
   });
+
+  it("should return 403 error if the flag has_remote_content is true but the feature_level_type is not provided", async () => {
+    const createMessageHandler = CreateMessageHandler(
+      mockTelemetryClient,
+      mockMessageModel,
+      undefined as any,
+      mockSaveBlob,
+      true,
+      [],
+      aSandboxFiscalCode
+    );
+
+    const r = await createMessageHandler(
+      createContext(),
+      anAzureApiAuthorization,
+      undefined as any,
+      anAzureUserAttributes,
+      {
+        content: {
+          markdown: "md",
+          subject: "subject",
+          third_party_data: { has_attachments: true }
+        }
+      } as ApiNewMessageWithDefaults,
+      some(anotherFiscalCode)
+    );
+
+    expect(r.kind).toBe("IResponseErrorForbiddenNotAuthorizedForAttachments");
+    expect(r.detail).toBe(
+      "Attachments call forbidden: You are not allowed to send messages with attachmens with STANDARD messages, please use ADVANCED"
+    );
+  });
 });

--- a/CreateMessage/__tests__/handler.test.ts
+++ b/CreateMessage/__tests__/handler.test.ts
@@ -44,6 +44,7 @@ import {
 import { initAppInsights } from "@pagopa/ts-commons/lib/appinsights";
 import { ApiNewMessageWithDefaults } from "../types";
 import { Context } from "@azure/functions";
+import { FeatureLevelTypeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/FeatureLevelType";
 
 const createContext = (): Context =>
   (({
@@ -57,14 +58,12 @@ const aSandboxFiscalCode = "AAAAAA12A12A111A" as NonEmptyString;
 
 const mockTelemetryClient = ({
   trackEvent: jest.fn()
-  } as unknown) as ReturnType<typeof initAppInsights>;
+} as unknown) as ReturnType<typeof initAppInsights>;
 
-const mockSaveBlob = jest.fn((_: string, __: any) =>
-  TE.of(O.some({} as any))
-  );
+const mockSaveBlob = jest.fn((_: string, __: any) => TE.of(O.some({} as any)));
 const mockMessageModel = ({
   create: jest.fn(() => TE.of({}))
-  } as unknown) as MessageModel;
+} as unknown) as MessageModel;
 
 //
 // tests
@@ -414,6 +413,39 @@ describe("CreateMessageHandler", () => {
           requireSecureChannels: false
         })
       })
+    );
+  });
+
+  it("should return 403 error if the flag has_remote_content is true but the message is not advanced", async () => {
+    const createMessageHandler = CreateMessageHandler(
+      mockTelemetryClient,
+      mockMessageModel,
+      undefined as any,
+      mockSaveBlob,
+      true,
+      [],
+      aSandboxFiscalCode
+    );
+
+    const r = await createMessageHandler(
+      createContext(),
+      anAzureApiAuthorization,
+      undefined as any,
+      anAzureUserAttributes,
+      {
+        content: {
+          markdown: "md",
+          subject: "subject",
+          third_party_data: { has_attachments: true }
+        },
+        feature_level_type: FeatureLevelTypeEnum.STANDARD
+      } as ApiNewMessageWithDefaults,
+      some(anotherFiscalCode)
+    );
+
+    expect(r.kind).toBe("IResponseErrorForbiddenNotAuthorizedForAttachments");
+    expect(r.detail).toBe(
+      "Attachments call forbidden: You are not allowed to send messages with attachmens with STANDARD messages, please use ADVANCED"
     );
   });
 });

--- a/CreateMessage/handler.ts
+++ b/CreateMessage/handler.ts
@@ -307,11 +307,13 @@ export function CreateMessageHandler(
     const { service, email: serviceUserEmail } = userAttributes;
     const { authorizedRecipients, serviceId } = service;
 
-    const canSendAttachments =
-      messagePayload.feature_level_type !== FeatureLevelTypeEnum.ADVANCED &&
+    const isPremium =
+      messagePayload.feature_level_type === FeatureLevelTypeEnum.ADVANCED;
+
+    const wantToSendAttachments =
       messagePayload.content.third_party_data?.has_attachments === true;
 
-    if (canSendAttachments) {
+    if (!isPremium && wantToSendAttachments) {
       return ResponseErrorForbiddenNotAuthorizedForAttachments;
     }
 

--- a/CreateMessage/handler.ts
+++ b/CreateMessage/handler.ts
@@ -307,11 +307,12 @@ export function CreateMessageHandler(
     const { service, email: serviceUserEmail } = userAttributes;
     const { authorizedRecipients, serviceId } = service;
 
-    // in order to send attachments with a message the message should be ADVANCED
-    if (
+    const canSendAttachments =
       messagePayload.feature_level_type === FeatureLevelTypeEnum.STANDARD &&
-      messagePayload.content.third_party_data.has_attachments === true
-    ) {
+      messagePayload.content.third_party_data.has_attachments === true;
+
+    // in order to send attachments with a message the message should be ADVANCED
+    if (canSendAttachments) {
       return ResponseErrorForbiddenNotAuthorizedForAttachments;
     }
 

--- a/CreateMessage/handler.ts
+++ b/CreateMessage/handler.ts
@@ -307,11 +307,12 @@ export function CreateMessageHandler(
     const { service, email: serviceUserEmail } = userAttributes;
     const { authorizedRecipients, serviceId } = service;
 
+    // in order to send attachments with a message the message should be ADVANCED
     const canSendAttachments =
-      messagePayload.feature_level_type === FeatureLevelTypeEnum.STANDARD &&
+      (messagePayload.feature_level_type === FeatureLevelTypeEnum.STANDARD ||
+        !messagePayload.feature_level_type) &&
       messagePayload.content.third_party_data.has_attachments === true;
 
-    // in order to send attachments with a message the message should be ADVANCED
     if (canSendAttachments) {
       return ResponseErrorForbiddenNotAuthorizedForAttachments;
     }

--- a/CreateMessage/handler.ts
+++ b/CreateMessage/handler.ts
@@ -307,11 +307,9 @@ export function CreateMessageHandler(
     const { service, email: serviceUserEmail } = userAttributes;
     const { authorizedRecipients, serviceId } = service;
 
-    // in order to send attachments with a message the message should be ADVANCED
     const canSendAttachments =
-      (messagePayload.feature_level_type === FeatureLevelTypeEnum.STANDARD ||
-        !messagePayload.feature_level_type) &&
-      messagePayload.content.third_party_data.has_attachments === true;
+      messagePayload.feature_level_type !== FeatureLevelTypeEnum.ADVANCED &&
+      messagePayload.content.third_party_data?.has_attachments === true;
 
     if (canSendAttachments) {
       return ResponseErrorForbiddenNotAuthorizedForAttachments;

--- a/CreateMessage/handler.ts
+++ b/CreateMessage/handler.ts
@@ -51,6 +51,8 @@ import {
 import { initAppInsights } from "@pagopa/ts-commons/lib/appinsights";
 import { readableReportSimplified } from "@pagopa/ts-commons/lib/reporters";
 import {
+  HttpStatusCodeEnum,
+  IResponse,
   IResponseErrorForbiddenAnonymousUser,
   IResponseErrorForbiddenNoAuthorizationGroups,
   IResponseErrorForbiddenNotAuthorized,
@@ -61,6 +63,7 @@ import {
   IResponseSuccessRedirectToResource,
   ResponseErrorForbiddenNotAuthorizedForProduction,
   ResponseErrorForbiddenNotAuthorizedForRecipient,
+  ResponseErrorGeneric,
   ResponseErrorInternal,
   ResponseErrorValidation,
   ResponseSuccessRedirectToResource
@@ -74,6 +77,7 @@ import { TaskEither } from "fp-ts/lib/TaskEither";
 import { PaymentDataWithRequiredPayee } from "@pagopa/io-functions-commons/dist/generated/definitions/PaymentDataWithRequiredPayee";
 import { NewMessage as ApiNewMessage } from "@pagopa/io-functions-commons/dist/generated/definitions/NewMessage";
 import { StandardServiceCategoryEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/StandardServiceCategory";
+import { FeatureLevelTypeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/FeatureLevelType";
 import {
   CommonMessageData,
   CreatedMessageEvent
@@ -113,6 +117,7 @@ type ICreateMessageHandler = (
   | IResponseErrorForbiddenNotAuthorized
   | IResponseErrorForbiddenNotAuthorizedForRecipient
   | IResponseErrorForbiddenNotAuthorizedForProduction
+  | IResponseErrorForbiddenNotAuthorizedForAttachments
 >;
 
 export type CreateMessageHandlerResponse = PromiseType<
@@ -145,6 +150,22 @@ export const canWriteMessage = (
   }
 
   return E.right(true);
+};
+
+/**
+ * The user is not allowed to issue production requests.
+ */
+export type IResponseErrorForbiddenNotAuthorizedForAttachments = IResponse<
+  "IResponseErrorForbiddenNotAuthorizedForAttachments"
+>;
+
+export const ResponseErrorForbiddenNotAuthorizedForAttachments: IResponseErrorForbiddenNotAuthorizedForAttachments = {
+  ...ResponseErrorGeneric(
+    HttpStatusCodeEnum.HTTP_STATUS_403,
+    "Attachments call forbidden",
+    "You are not allowed to send messages with attachmens with STANDARD messages, please use ADVANCED"
+  ),
+  kind: "IResponseErrorForbiddenNotAuthorizedForAttachments"
 };
 
 /**
@@ -241,7 +262,7 @@ const redirectToNewMessage = (
 /**
  * Returns a type safe CreateMessage handler.
  */
-// eslint-disable-next-line prefer-arrow/prefer-arrow-functions,max-params
+// eslint-disable-next-line prefer-arrow/prefer-arrow-functions,max-params, max-lines-per-function
 export function CreateMessageHandler(
   telemetryClient: ReturnType<typeof initAppInsights>,
   messageModel: MessageModel,
@@ -285,6 +306,14 @@ export function CreateMessageHandler(
     const fiscalCode = maybeFiscalCode.value;
     const { service, email: serviceUserEmail } = userAttributes;
     const { authorizedRecipients, serviceId } = service;
+
+    // in order to send attachments with a message the message should be ADVANCED
+    if (
+      messagePayload.feature_level_type === FeatureLevelTypeEnum.STANDARD &&
+      messagePayload.content.third_party_data.has_attachments === true
+    ) {
+      return ResponseErrorForbiddenNotAuthorizedForAttachments;
+    }
 
     // a new message ID gets generated for each request, even for requests that
     // fail as it's used as a unique operation identifier in application


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

* [Return 403 if attachments are provided with a non premium message](https://github.com/pagopa/io-functions-services/commit/e9a9bc5edbc9dfdaa4f880c3faa270abcf5b7064)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

We want to open the possibility to send `third_party_data` to all the services in order to open the remote content.
On the other hand attachments should be available only for premium messages.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

unit test.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
