### PR TITLE
[#IOCOM-987] Invalidate clickable links in email

### DIFF
--- a/EmailNotification/__tests__/__snapshots__/utils.test.ts.snap
+++ b/EmailNotification/__tests__/__snapshots__/utils.test.ts.snap
@@ -388,7 +388,7 @@ Object {
                               </tr>
                               <tr>
                                 <td align=\\"left\\" class=\\"text\\" style=\\"font-size:0px;padding:0px;word-break:break-word;\\">
-                                  <div style=\\"font-family:Titillium Web, system-ui, sans-serif;font-size:16px;font-weight:regular;line-height:24px;text-align:left;color:#17324D;\\"><p>testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttestte...</p></div>
+                                  <div style=\\"font-family:Titillium Web, system-ui, sans-serif;font-size:16px;font-weight:regular;line-height:24px;text-align:left;color:#17324D;\\"><p>testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttestte.​.​.​</p></div>
                                 </td>
                               </tr>
                             </tbody>

--- a/EmailNotification/__tests__/handler.test.ts
+++ b/EmailNotification/__tests__/handler.test.ts
@@ -226,7 +226,7 @@ describe("prepareBody", () => {
       "# Header 1\nsome text\n## Header 2\nsome text\n### Header 3\nsome text\n#### Header 4\nsome text\n##### Header 5\nsome text\ntestesttesttesttestesttesttesttestesttesttesttestesttesttesttestesttesttesttestesttesttest";
     const r = prepareBody(markdown);
     //this should be 134 + 3 cause "..." is added at the end
-    expect(r).toHaveLength(137);
+    expect(r).toHaveLength(140);
     expect(r).not.toContain("#");
   });
 });

--- a/EmailNotification/__tests__/utils.test.ts
+++ b/EmailNotification/__tests__/utils.test.ts
@@ -113,8 +113,8 @@ describe("removeLinks", () => {
 
 describe("invalidateClickableLinks", () => {
   test("should return the same string if no period are provided", () => {
-    expect(invalidateClickableLinks("a simple text with no perios")).toBe(
-      "a simple text with no perios"
+    expect(invalidateClickableLinks("a simple text with no period")).toBe(
+      "a simple text with no period"
     );
   });
 

--- a/EmailNotification/__tests__/utils.test.ts
+++ b/EmailNotification/__tests__/utils.test.ts
@@ -1,5 +1,6 @@
 import {
   contentToHtml,
+  invalidateClickableLinks,
   messageReducedToHtml,
   removeLinks,
   truncateMarkdown
@@ -106,6 +107,20 @@ describe("removeLinks", () => {
     const baseText = `A simple text`;
     expect(removeLinks(`${baseText} ${simpleLink}`)).toBe(
       `${baseText} [link rimosso]`
+    );
+  });
+});
+
+describe("invalidateClickableLinks", () => {
+  test("should return the same string if no period are provided", () => {
+    expect(invalidateClickableLinks("a simple text with no perios")).toBe(
+      "a simple text with no perios"
+    );
+  });
+
+  test("should add a zero-width space before every '.' character", () => {
+    expect(invalidateClickableLinks("a text.with 2 period.")).toBe(
+      "a text.\u{200B}with 2 period.\u{200B}"
     );
   });
 });

--- a/EmailNotification/__tests__/utils.test.ts
+++ b/EmailNotification/__tests__/utils.test.ts
@@ -78,18 +78,34 @@ describe("removeLinks", () => {
   test("should return the string without the url if a simple url is contained", () => {
     const simpleLink = "https://asimplelink.com/";
     const baseText = `A simple text`;
-    expect(removeLinks(`${baseText}${simpleLink}`)).toBe(baseText);
+    expect(removeLinks(`${baseText} ${simpleLink}`)).toBe(
+      `${baseText} [link rimosso]`
+    );
+  });
+
+  test("should return the string without the url if more than one simple url are contained", () => {
+    const simpleLink = "https://asimplelink.com/";
+    const baseText = `A simple text`;
+    expect(
+      removeLinks(
+        `${baseText} ${simpleLink} this is another link ${simpleLink}`
+      )
+    ).toBe(`${baseText} [link rimosso] this is another link [link rimosso]`);
   });
 
   test("should return the string without the url if an url with query params is contained", () => {
     const simpleLink = "https://asimplelink.com/?qp1=value";
     const baseText = `A simple text`;
-    expect(removeLinks(`${baseText}${simpleLink}`)).toBe(baseText);
+    expect(removeLinks(`${baseText} ${simpleLink}`)).toBe(
+      `${baseText} [link rimosso]`
+    );
   });
 
   test("should return the string without the url if an url with query params and # is contained ", () => {
     const simpleLink = "https://asimplelink.com/?qp1=value#header";
     const baseText = `A simple text`;
-    expect(removeLinks(`${baseText}${simpleLink}`)).toBe(baseText);
+    expect(removeLinks(`${baseText} ${simpleLink}`)).toBe(
+      `${baseText} [link rimosso]`
+    );
   });
 });

--- a/EmailNotification/__tests__/utils.test.ts
+++ b/EmailNotification/__tests__/utils.test.ts
@@ -118,7 +118,7 @@ describe("invalidateClickableLinks", () => {
     );
   });
 
-  test("should add a zero-width space before every '.' character", () => {
+  test("should add a zero-width space after every '.' character", () => {
     expect(invalidateClickableLinks("a text.with 2 period.")).toBe(
       "a text.\u{200B}with 2 period.\u{200B}"
     );

--- a/EmailNotification/utils.ts
+++ b/EmailNotification/utils.ts
@@ -129,8 +129,8 @@ export const prepareBody = (markdown: string): string =>
     markdown.split("---").pop(),
     removeMd,
     removeLinks,
-    invalidateClickableLinks,
-    truncateMarkdown
+    truncateMarkdown,
+    invalidateClickableLinks
   );
 
 type MessageReducedToHtmlOutput = ({

--- a/EmailNotification/utils.ts
+++ b/EmailNotification/utils.ts
@@ -114,7 +114,7 @@ export const truncateMarkdown = (plainText: string): string =>
     : plainText.substring(0, MAX_CHARACTER_FOR_BODY_MAIL);
 
 export const removeLinks = (text: string): string =>
-  text.replace(/(?:https?|ftp):\/\/[\n\S]+/g, "[link rimosso]");
+  text.replace(/\w+:\/\/[^\s]*\.\w+[\w\?\/=%&#+-]+/g, "[link rimosso]");
 
 /**
  * Add a zero-width space before every '.' character in order to makke all the links not clickable

--- a/EmailNotification/utils.ts
+++ b/EmailNotification/utils.ts
@@ -124,8 +124,8 @@ export const invalidateClickableLinks = (text: string): string =>
   text.replace(/\./g, ".\u{200B}");
 
 export const prepareBody = (markdown: string): string =>
-  // eslint-disable-next-line functional/immutable-data
   pipe(
+    // eslint-disable-next-line functional/immutable-data
     markdown.split("---").pop(),
     removeMd,
     removeLinks,

--- a/EmailNotification/utils.ts
+++ b/EmailNotification/utils.ts
@@ -128,8 +128,8 @@ export const prepareBody = (markdown: string): string =>
     // eslint-disable-next-line functional/immutable-data
     markdown.split("---").pop(),
     removeMd,
-    removeLinks,
     truncateMarkdown,
+    removeLinks,
     invalidateClickableLinks
   );
 

--- a/EmailNotification/utils.ts
+++ b/EmailNotification/utils.ts
@@ -114,7 +114,7 @@ export const truncateMarkdown = (plainText: string): string =>
     : plainText.substring(0, MAX_CHARACTER_FOR_BODY_MAIL);
 
 export const removeLinks = (text: string): string =>
-  text.replace(/\w+:\/\/[^\s]*\.\w+[\w\?\/=%&#+-]+/g, "[link rimosso]");
+  text.replace(/\w*:\/\/[^\s]*\.[\w?/=&%-+#]*/g, "[link rimosso]");
 
 /**
  * Add a zero-width space before every '.' character in order to makke all the links not clickable

--- a/EmailNotification/utils.ts
+++ b/EmailNotification/utils.ts
@@ -114,11 +114,24 @@ export const truncateMarkdown = (plainText: string): string =>
     : plainText.substring(0, MAX_CHARACTER_FOR_BODY_MAIL);
 
 export const removeLinks = (text: string): string =>
-  text.replace(/(?:https?|ftp):\/\/[\n\S]+/g, "");
+  text.replace(/(?:https?|ftp):\/\/[\n\S]+/g, "[link rimosso]");
+
+/**
+ * Add a zero-width space before every '.' character in order to makke all the links not clickable
+ * */
+
+export const invalidateClickableLinks = (text: string): string =>
+  text.replace(/\./g, ".\u{200B}");
 
 export const prepareBody = (markdown: string): string =>
   // eslint-disable-next-line functional/immutable-data
-  pipe(markdown.split("---").pop(), removeMd, truncateMarkdown, removeLinks);
+  pipe(
+    markdown.split("---").pop(),
+    removeMd,
+    removeLinks,
+    invalidateClickableLinks,
+    truncateMarkdown
+  );
 
 type MessageReducedToHtmlOutput = ({
   content,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

* [Replace links with a warning](https://github.com/pagopa/io-functions-services/commit/eaad9b401b2cd2928d3d462a111831d3b8e56fe2);
* [Invalidate clickable links](https://github.com/pagopa/io-functions-services/commit/c17647a887e0864be89a936397ff2bb746af22cc);

The text where we are using the regex will always been of 134 character so we are not affected by the problem highlighted by sonar.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

We want to avoid clickable links in email

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
