### PR TITLE
[#IOPAE-1053] ServiceHistory Manage API and mandatory Topic_Id

### DIFF
--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -2201,8 +2201,6 @@ definitions:
             type: string
           status:
             $ref: '#/definitions/CmsServiceHistoryItemStatus'
-          version:
-            type: integer
           last_update:
             $ref: '#/definitions/Timestamp'
           metadata:

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -803,6 +803,58 @@ paths:
           description: Internal server error
           schema:
             $ref: '#/definitions/ProblemJson'
+  /manage/services/{serviceId}/history:
+    get:
+      tags:
+        - manage
+      summary: Retrieve service history
+      description: Retrieve service history by service ID
+      operationId: cmsGetServiceHistory
+      parameters:
+        - name: serviceId
+          in: path
+          description: ID of the service
+          required: true
+          type: string
+        - name: order
+          in: query
+          description: Order direction
+          required: false
+          type: string
+          enum:
+            - ASC
+            - DESC
+          default: DESC
+        - name: limit
+          in: query
+          description: The number of services to return
+          required: false
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 10
+        - name: continuationToken
+          in: query
+          description: Token to retrieve the next page of results
+          required: false
+          type: string
+      responses:
+        '200':
+          description: Service history retrieved successfully
+          schema:
+            $ref: '#/definitions/CmsServiceHistory'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+        '429':
+          description: Too many requests
+        '500':
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/ProblemJson'
   /manage/services/{serviceId}/keys:
     get:
       tags:
@@ -2000,6 +2052,8 @@ definitions:
             type: number
             description: The topic id
             example: 3
+        required:
+          - topic_id
   CmsServiceLifecycleStatus:
     type: object
     properties:
@@ -2127,6 +2181,76 @@ definitions:
     required:
       - id
       - name
+  CmsServiceHistory:
+    type: object
+    description: Service basic data
+    properties:
+      continuationToken:
+        type: string
+        description: Continuation token for pagination
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/CmsServiceHistoryItem'
+  CmsServiceHistoryItem:
+    description: Service History model data
+    allOf:
+      - type: object
+        properties:
+          id:
+            type: string
+          status:
+            $ref: '#/definitions/CmsServiceHistoryItemStatus'
+          version:
+            type: integer
+          last_update:
+            $ref: '#/definitions/Timestamp'
+          metadata:
+            $ref: '#/definitions/CmsServiceMetadata'
+        required:
+          - id
+          - status
+          - last_update
+          - metadata
+      - $ref: '#/definitions/CmsServiceData'
+  CmsServiceHistoryItemStatus:
+    type: object
+    properties:
+      kind:
+        $ref: '#/definitions/CmsServiceHistoryStatusKind'
+      value:
+        $ref: '#/definitions/CmsServiceHistoryStatusType'
+      reason:
+        description: Reason for status value
+        type: string
+    required:
+      - value
+  CmsServiceHistoryStatusKind:
+    description: >
+      Status kind for Service History<br>
+
+      - publication: Indicates the status is related to a service-publication
+      event
+
+      - lifecycle: Indicates the status is related to a service-lifecycle event
+    type: string
+    enum:
+      - publication
+      - lifecycle
+  CmsServiceHistoryStatusType:
+    description: >
+      A Service History record contains either publication or lifecycle items,
+      so can have a combination of Service lifecycle status and publication
+      status<br>
+    type: string
+    enum:
+      - draft
+      - submitted
+      - approved
+      - rejected
+      - deleted
+      - published
+      - unpublished
 responses: {}
 parameters:
   LegalMail:

--- a/openapi/index.yaml.template
+++ b/openapi/index.yaml.template
@@ -747,6 +747,56 @@ paths:
           description: Internal server error
           schema:
             $ref: "#/definitions/ProblemJson"
+  "/manage/services/{serviceId}/history":
+    get:
+      tags:
+        - manage
+      summary: Retrieve service history
+      description: Retrieve service history by service ID
+      operationId: cmsGetServiceHistory
+      parameters:
+        - name: serviceId
+          in: path
+          description: ID of the service
+          required: true
+          type: string
+        - name: order
+          in: query
+          description: Order direction
+          required: false
+          type: string
+          enum: [ASC, DESC]
+          default: DESC
+        - name: limit
+          in: query
+          description: The number of services to return
+          required: false
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 10
+        - name: continuationToken
+          in: query
+          description: Token to retrieve the next page of results
+          required: false
+          type: string
+      responses:
+        "200":
+          description: Service history retrieved successfully
+          schema:
+            $ref: "#/definitions/CmsServiceHistory"
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not found
+        "429":
+          description: Too many requests
+        "500":
+          description: Internal server error
+          schema:
+            $ref: "#/definitions/ProblemJson"
   "/manage/services/{serviceId}/keys":
     get:
       tags:
@@ -1288,6 +1338,8 @@ definitions:
             type: number
             description: The topic id
             example: 3
+        required:
+          - topic_id
   CmsServiceLifecycleStatus:
     type: object
     properties:
@@ -1393,6 +1445,62 @@ definitions:
     required:
       - id
       - name
+  CmsServiceHistory:
+    type: object
+    description: Service basic data
+    properties:
+      continuationToken:
+        type: string
+        description: Continuation token for pagination
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/CmsServiceHistoryItem'
+  CmsServiceHistoryItem:
+    description: Service History model data
+    allOf:
+      - type: object
+        properties:
+          id:
+            type: string
+          status:
+            $ref: '#/definitions/CmsServiceHistoryItemStatus'
+          version:
+            type: integer
+          last_update:
+            $ref: '#/definitions/Timestamp'
+          metadata:
+            $ref: '#/definitions/CmsServiceMetadata'
+        required:
+          - id
+          - status
+          - last_update
+          - metadata
+      - $ref: '#/definitions/CmsServiceData'
+  CmsServiceHistoryItemStatus:
+    type: object
+    properties:
+      kind:
+        $ref: '#/definitions/CmsServiceHistoryStatusKind'
+      value:
+        $ref: '#/definitions/CmsServiceHistoryStatusType'
+      reason:
+        description: Reason for status value
+        type: string
+    required:
+      - value
+  CmsServiceHistoryStatusKind:
+    description: |
+      Status kind for Service History<br>
+      - publication: Indicates the status is related to a service-publication event
+      - lifecycle: Indicates the status is related to a service-lifecycle event
+    type: string
+    enum: [publication, lifecycle]
+  CmsServiceHistoryStatusType:
+    description: |
+      A Service History record contains either publication or lifecycle items, so can have a combination of Service lifecycle status and publication status<br>
+    type: string
+    enum: [draft, submitted, approved, rejected, deleted, published, unpublished]
 
 responses: {}
 parameters:

--- a/openapi/index.yaml.template
+++ b/openapi/index.yaml.template
@@ -1465,8 +1465,6 @@ definitions:
             type: string
           status:
             $ref: '#/definitions/CmsServiceHistoryItemStatus'
-          version:
-            type: integer
           last_update:
             $ref: '#/definitions/Timestamp'
           metadata:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Add ServiceHistory Manage API, Topic_Id is now mandatory on manage create and manage update service
#### List of Changes
- Add `GET /manage/services/{serviceId}/history` API
- `topic_id` field is now mandatory on Json Body for `PUT /manage/services/{serviceId}` and `POST /manage/services` APIs
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
