### PR TITLE
[#IOCOM-1597] Managed LEGACY user as app UNKNOWN

### DIFF
--- a/GetMessage/userPreferenceChecker/__tests__/messageReadStatusAuth.test.ts
+++ b/GetMessage/userPreferenceChecker/__tests__/messageReadStatusAuth.test.ts
@@ -93,7 +93,12 @@ describe("canAccessMessageReadStatus |> ok", () => {
 
   it("should return false if profile servicePreferencesSettings is of type LEGACY (version is -1)", async () => {
     mockProfileFindLastVersionByModelId.mockReturnValueOnce(
-      TE.of(O.some(aRetrievedProfile))
+      TE.of(
+        O.some({
+          ...aRetrievedProfile,
+          lastAppVersion: MIN_READ_STATUS_PREFERENCES_VERSION
+        })
+      )
     );
 
     const res = await canAccessMessageReadStatus(
@@ -268,9 +273,7 @@ describe("canAccessMessageReadStatus |> Errors", () => {
       MIN_READ_STATUS_PREFERENCES_VERSION
     )(aServiceId, aFiscalCode)();
 
-    expect(res).toStrictEqual(
-      E.right(false)
-    );
+    expect(res).toStrictEqual(E.right(false));
 
     // Do not call service preferences like if app version is UNKNOWN
     expect(mockServicePreferencesFind).not.toHaveBeenCalled();

--- a/GetMessage/userPreferenceChecker/__tests__/messageReadStatusAuth.test.ts
+++ b/GetMessage/userPreferenceChecker/__tests__/messageReadStatusAuth.test.ts
@@ -250,4 +250,29 @@ describe("canAccessMessageReadStatus |> Errors", () => {
       E.left(Error("Error retrieving user' service preferences from Cosmos DB"))
     );
   });
+
+  it("should return false if profile servicePreferencesSettings is of type LEGACY", async () => {
+    mockProfileFindLastVersionByModelId.mockReturnValueOnce(
+      TE.of(
+        O.some({
+          ...aRetrievedProfile,
+          lastAppVersion: MIN_READ_STATUS_PREFERENCES_VERSION,
+          servicePreferencesSettings: legacyProfileServicePreferencesSettings
+        })
+      )
+    );
+
+    const res = await canAccessMessageReadStatus(
+      profileModel,
+      servicePreferenceModel,
+      MIN_READ_STATUS_PREFERENCES_VERSION
+    )(aServiceId, aFiscalCode)();
+
+    expect(res).toStrictEqual(
+      E.right(false)
+    );
+
+    // Do not call service preferences like if app version is UNKNOWN
+    expect(mockServicePreferencesFind).not.toHaveBeenCalled();
+  });
 });

--- a/GetMessage/userPreferenceChecker/__tests__/userPreferencesCheckerFactory.test.ts
+++ b/GetMessage/userPreferenceChecker/__tests__/userPreferencesCheckerFactory.test.ts
@@ -145,7 +145,7 @@ describe("userPreferencesCheckerFactory |> userPreferencesCheckerFactory", () =>
     const res = await userPreferencesCheckerFactory(
       {
         ...aRetrievedProfile,
-        lastAppVersion: "UNKNOWN"
+        lastAppVersion: MIN_READ_STATUS_PREFERENCES_VERSION
       },
       mockServicePreferencesGetter,
       MIN_READ_STATUS_PREFERENCES_VERSION

--- a/GetMessage/userPreferenceChecker/__tests__/userPreferencesCheckerFactory.test.ts
+++ b/GetMessage/userPreferenceChecker/__tests__/userPreferencesCheckerFactory.test.ts
@@ -20,7 +20,8 @@ import {
 import {
   aFiscalCode,
   aRetrievedProfile,
-  aServiceId
+  aServiceId,
+  autoProfileServicePreferencesSettings
 } from "../../../__mocks__/mocks";
 
 const MIN_READ_STATUS_PREFERENCES_VERSION = "1.15.3" as Semver;
@@ -138,6 +139,24 @@ describe("userPreferencesCheckerFactory |> userPreferencesCheckerFactory", () =>
     expect(res).toStrictEqual(E.right(false));
   });
 
+  it("should call userPreferenceCheckerVersionUNKNOWNToVersionWithReadAuth if profile servicePreferencesSettings is of type LEGACY (version is -1)", async () => {
+    mockServicePreferencesGetter.mockReturnValueOnce(TE.of(O.none));
+
+    const res = await userPreferencesCheckerFactory(
+      {
+        ...aRetrievedProfile,
+        lastAppVersion: "UNKNOWN"
+      },
+      mockServicePreferencesGetter,
+      MIN_READ_STATUS_PREFERENCES_VERSION
+    ).canAccessMessageReadStatus(aServiceId, aFiscalCode)();
+
+    expect(spyUnknownImplementation).toHaveBeenCalled();
+    expect(spyVersionGreaterThanImplementation).not.toHaveBeenCalled();
+
+    expect(res).toStrictEqual(E.right(false));
+  });
+
   it("should call userPreferenceCheckerVersionUNKNOWNToVersionWithReadAuth if appVersion is < MIN_READ_STATUS_PREFERENCES_VERSION", async () => {
     mockServicePreferencesGetter.mockReturnValueOnce(TE.of(O.none));
 
@@ -162,6 +181,7 @@ describe("userPreferencesCheckerFactory |> userPreferencesCheckerFactory", () =>
     const res = await userPreferencesCheckerFactory(
       {
         ...aRetrievedProfile,
+        servicePreferencesSettings: autoProfileServicePreferencesSettings,
         lastAppVersion: MIN_READ_STATUS_PREFERENCES_VERSION
       },
       mockServicePreferencesGetter,
@@ -180,6 +200,7 @@ describe("userPreferencesCheckerFactory |> userPreferencesCheckerFactory", () =>
     const res = await userPreferencesCheckerFactory(
       {
         ...aRetrievedProfile,
+        servicePreferencesSettings: autoProfileServicePreferencesSettings,
         lastAppVersion: NEWER_APP_VERSION
       },
       mockServicePreferencesGetter,

--- a/GetMessage/userPreferenceChecker/userPreferencesCheckerFactory.ts
+++ b/GetMessage/userPreferenceChecker/userPreferencesCheckerFactory.ts
@@ -16,6 +16,7 @@ import {
   ServicePreference
 } from "@pagopa/io-functions-commons/dist/src/models/service_preference";
 import { Semver } from "@pagopa/ts-commons/lib/strings";
+import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
 
 /**
  * It return the right UserPreferenceChecker, based on user's appVersion
@@ -38,7 +39,8 @@ export const userPreferencesCheckerFactory: UserPreferenceCheckerFactory = (
       !isAppVersionHandlingReadAuthorization(
         minAppVersionHandlingReadAuth,
         version
-      ),
+      ) ||
+      !NonNegativeInteger.is(profile.servicePreferencesSettings.version),
     b.match(
       () => userPreferenceCheckerVersionWithReadAuth(servicePreferencesGetter),
       () => userPreferenceCheckerVersionUNKNOWNToVersionWithReadAuth


### PR DESCRIPTION
#### List of Changes
Added check to manage LEGACY user service preference as UNKNOWN like if we do not know the user's app version.

#### Motivation and Context
We need to manage users with LEGACY service preferences because actually they were not considered to exists.

#### How Has This Been Tested?
- build
- unit test
- lint 

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. **RFC + DR**
